### PR TITLE
Fix broken logo when using non-localhost URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
       "server": "server/main.js"
     },
     "testModule": "tests/main.js"
+  },
+  "staticAssets": {
+    "exportAbsolutePaths": false
   }
 }


### PR DESCRIPTION
See [documentation](https://github.com/nathantreid/meteor-static-assets#options) for information on `exportAbsolutePaths`
