### PR TITLE
Cron prof update + update unitNames when user edit site

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.3'
+wp_veritas_image_version: '1.3.4'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.2'
+wp_veritas_image_version: '1.3.3'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"

--- a/app/client/index.css
+++ b/app/client/index.css
@@ -54,6 +54,7 @@ table {
   top: -3px;
   right: -3px
 }
+
 .ribbon {
   font-size: 12px;
   color: #007bff;
@@ -81,7 +82,8 @@ table {
   background-image: -o-linear-gradient(top, #ffffff 45%, #dedede 100%);
   background-image: linear-gradient(to bottom, #ffffff 45%, #dedede 100%);
   background-repeat: repeat-x;
-  filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffdedede', GradientType=0)
+  filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffdedede', GradientType=0);
+  z-index: 1000;
 }
 
 .ribbon:before,

--- a/app/imports/api/methods.js
+++ b/app/imports/api/methods.js
@@ -74,6 +74,31 @@ function prepareUpdateInsert(site, action) {
   return site;
 }
 
+function getUnitNames(unitId) {
+
+  // Ldap search to get unitName and unitLevel2
+  let unit = Meteor.apply('getUnitFromLDAP', [unitId], true);
+  let unitName = '';
+  let unitNameLevel2 = '';
+  
+  if ('cn' in unit) {
+    unitName = unit.cn;
+  }
+  
+  if ('dn' in unit) {
+    let dn = unit.dn.split(",");
+    if (dn.length == 5) {
+      // dn[2] = 'ou=associations'
+      unitNameLevel2 = dn[2].split("=")[1];
+    }
+  }
+
+  return {
+    unitName: unitName,
+    unitNameLevel2: unitNameLevel2,
+  };
+}
+
 Meteor.methods({
 
   async getUserFromLDAP(sciper) {
@@ -329,21 +354,7 @@ Meteor.methods({
     }
     site = prepareUpdateInsert(site, 'insert');
 
-    // Ldap search to get unitName and unitLevel2
-    let unit = Meteor.apply('getUnitFromLDAP', [site.unitId], true);
-    let unitName = '';
-    let unitNameLevel2 = '';
-    if ('cn' in unit) {
-        unitName = unit.cn;
-    }
-    if ('dn' in unit) {
-        let dn = unit.dn.split(",");
-        if (dn.length == 5) {
-        // dn[2] = 'ou=associations'
-        unitNameLevel2 = dn[2].split("=")[1];
-        }
-    }
-
+    const { unitName, unitNameLevel2 } = getUnitNames(site.unitId);
     console.log('Insert new site with unitName: ', unitName);
     console.log('Insert new site with unitNameLevel2:', unitNameLevel2);
 
@@ -482,6 +493,10 @@ Meteor.methods({
 
     site = prepareUpdateInsert(site, 'update');
 
+    const { unitName, unitNameLevel2 } = getUnitNames(site.unitId);
+    console.log('Insert new site with unitName: ', unitName);
+    console.log('Insert new site with unitNameLevel2:', unitNameLevel2);
+
     let siteDocument = {
       url: site.url,
       slug: site.slug,
@@ -492,6 +507,8 @@ Meteor.methods({
       theme: site.theme,
       languages: site.languages,
       unitId: site.unitId,
+      unitName: unitName,
+      unitNameLevel2: unitNameLevel2,
       snowNumber: site.snowNumber,
       comment: site.comment,
       createdDate: site.createdDate,

--- a/app/imports/api/methods.js
+++ b/app/imports/api/methods.js
@@ -111,12 +111,12 @@ Meteor.methods({
     });
     return result;
   },
-
-  async getUnitFromLDAP(sciper) {
+  
+  async getUnitFromLDAP(uniqueIdentifier) {
     let result;
     const publicLdapContext = require('epfl-ldap')();
     result = await new Promise(function (resolve, reject) {
-      publicLdapContext.units.getUnitByUniqueIdentifier(sciper, function(err, data) {
+      publicLdapContext.units.getUnitByUniqueIdentifier(uniqueIdentifier, function(err, data) {
         resolve(data);
       });
     });
@@ -962,21 +962,23 @@ Meteor.methods({
     let sites = Sites.find({}).fetch();
     sites.forEach(function(site) {
       new_professors = [];
-      site.professors.forEach(function(professor) {
-        if (professor._id === professorId) {
-          // we want delete this tag of current professor
-        } else {
-          new_professors.push(professor);
-        }
-      });
-      Sites.update(
-        {"_id": site._id},
-        {
-          $set: {
-            'professors': new_professors,
+      if ('professors' in site) {
+        site.professors.forEach(function(professor) {
+          if (professor._id === professorId) {
+            // we want delete this tag of current professor
+          } else {
+            new_professors.push(professor);
           }
-        }
-      );
+        });
+        Sites.update(
+          {"_id": site._id},
+          {
+            $set: {
+              'professors': new_professors,
+            }
+          }
+        );
+      }
     });
   },
 });

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.3</div>
+                  <div className="dropdown-item">Version 1.3.4</div>
                 </div>
               </li>
               : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.2</div>
+                  <div className="dropdown-item">Version 1.3.3</div>
                 </div>
               </li>
               : null}

--- a/app/imports/ui/components/professors/Professor.jsx
+++ b/app/imports/ui/components/professors/Professor.jsx
@@ -9,45 +9,10 @@ import { AlertSuccess, Loading } from '../Messages';
 
 class ProfessorsList extends Component {
 
-  constructor(props) {
-    super(props);
-    
-    this.state = {
-      updateLDAPSuccess: false,
-    }
-  }
-
-  updateLDAPInformations = () => {
-
-    let method = 'updateLDAPInformations';
-
-    Meteor.call(method, (error, result) => {
-      if (error) {
-        console.log(`ERROR ${error}`);
-      } else {
-        console.log("Success");
-        let state = { updateLDAPSuccess: true };
-        this.setState(state);
-      }
-    });
-  }
-
   render() { 
-    
-    let msgUpdateLDAPSuccess = (
-      <div className="alert alert-success" role="alert">
-        Les informations des professeurs ont été mise à jour avec succès ! 
-      </div> 
-    )
-
     return (
-      <Fragment>
-      { this.state.updateLDAPSuccess && msgUpdateLDAPSuccess }
       <div className="card my-2">
         <h5 className="card-header">Liste des professeurs</h5>
-        <div className="my-2 text-right">
-            <button id="updateLDAPButton" onClick={ (e) => this.updateLDAPInformations(e) } className="btn btn-primary">Mise à jour des professeurs</button>
-          </div>
         <ul className="list-group">
           {this.props.professors.map( (professor, index) => (
             <li id={ "sciper-" + professor.sciper } key={ professor._id } className="list-group-item">
@@ -60,7 +25,6 @@ class ProfessorsList extends Component {
           ))}
         </ul>
       </div>
-      </Fragment>
     )
   }
 }
@@ -105,7 +69,7 @@ class Professor extends Component {
 
   submitProfessor = async (values, actions) => {
     let state;
-    const getLDAPInformationsPromise = (method, values) => {
+    const getUserFromLDAPPromise = (method, values) => {
       return new Promise((resolve, reject) => {
         Meteor.call(method, values, (error, result) => {
           if (error) {
@@ -130,12 +94,12 @@ class Professor extends Component {
           } else {
             actions.setSubmitting(false);
             actions.resetForm();
-            this.setState(state);
+            this.setState({addSuccess: true, editSuccess: false, deleteSuccess: false, action: 'add'});
           }
         });
       });
     }
-    const ldapInfo = await getLDAPInformationsPromise('getLDAPInformations', values.sciper);
+    const ldapInfo = await getUserFromLDAPPromise('getUserFromLDAP', values.sciper);
     let infos = { 
       'sciper': ldapInfo.sciper, 
       'displayName': ldapInfo.displayName
@@ -165,7 +129,7 @@ class Professor extends Component {
     let content;
     let initialValues = this.getInitialValues();
     let isLoading = (this.props.professors == undefined || initialValues == undefined);
-
+  
     if (isLoading) {
       content = <Loading />;
     } else {
@@ -205,7 +169,6 @@ class Professor extends Component {
                 )}
             </Formik>
           </div>
-          
 
           { this.state.deleteSuccess ? ( 
             <AlertSuccess message={ 'Le professeur a été supprimé avec succès !' } />

--- a/app/imports/ui/components/sites/List.jsx
+++ b/app/imports/ui/components/sites/List.jsx
@@ -103,6 +103,7 @@ class List extends Component {
           "title",
           "tagline",
           "openshiftEnv",
+          "category",
           "theme",
           "faculty",
           "languages",

--- a/app/server/cron.js
+++ b/app/server/cron.js
@@ -3,7 +3,7 @@ import { Sites, Professors } from '../imports/api/collections';
 SyncedCron.add({
   name: 'Update professors name',
   schedule: function(parser) {
-    return parser.text('every 2 minutes');
+    return parser.text('every 24 hours');
   },
   job: function(intendedAt) {
     console.log("Update professors ...");
@@ -14,9 +14,6 @@ SyncedCron.add({
     professors.forEach(prof => {
       publicLdapContext.users.getUserBySciper(prof.sciper, function(err, user) {
 
-        console.log("Sciper: ", user.sciper);
-        console.log("Display name: ", user.displayName);
-        
         let professorDocument = {
           displayName: user.displayName,
         }
@@ -24,6 +21,9 @@ SyncedCron.add({
           { _id: prof._id }, 
           { $set: professorDocument }
         );
+
+        let profAfter = Professors.findOne(prof._id);
+        console.log(`Prof: ${profAfter.sciper} after update => DisplayName: ${profAfter.displayName}`);
         
       })
     });
@@ -31,7 +31,6 @@ SyncedCron.add({
   }
 });
 
-/*
 SyncedCron.add({
   name: 'Update unit names',
   schedule: function(parser) {
@@ -81,4 +80,3 @@ SyncedCron.add({
     console.log('All sites updated:', intendedAt);
   }
 });
-*/

--- a/app/server/cron.js
+++ b/app/server/cron.js
@@ -1,0 +1,84 @@
+import { Sites, Professors } from '../imports/api/collections';
+
+SyncedCron.add({
+  name: 'Update professors name',
+  schedule: function(parser) {
+    return parser.text('every 2 minutes');
+  },
+  job: function(intendedAt) {
+    console.log("Update professors ...");
+
+    const publicLdapContext = require('epfl-ldap')();
+    
+    let professors = Professors.find({}).fetch();
+    professors.forEach(prof => {
+      publicLdapContext.users.getUserBySciper(prof.sciper, function(err, user) {
+
+        console.log("Sciper: ", user.sciper);
+        console.log("Display name: ", user.displayName);
+        
+        let professorDocument = {
+          displayName: user.displayName,
+        }
+        Professors.update(
+          { _id: prof._id }, 
+          { $set: professorDocument }
+        );
+        
+      })
+    });
+    console.log('All professors updated:', intendedAt);
+  }
+});
+
+/*
+SyncedCron.add({
+  name: 'Update unit names',
+  schedule: function(parser) {
+    // Note: epfl-ldap-js cache is 4 hours
+    // Charles François said, "Changes in unit structure are currently only made once a night."
+    return parser.text('every 24 hours');
+  },
+  job: function(intendedAt) {
+    console.log("Update unitName and unitNameLevel2 of each site starting ...");
+    
+    const fullLdapContext = require('epfl-ldap')();
+    fullLdapContext.options.modelsMapper = fullLdapContext.viewModelsMappers.full;
+
+    // Update all sites
+    let sites = Sites.find({}).fetch();
+    sites.forEach(site => {
+
+      fullLdapContext.units.getUnitByUniqueIdentifier(site.unitId, function(err, unit) {
+
+        let unitName = '';
+        let unitNameLevel2 = '';
+
+        if ('cn' in unit) {
+          unitName = unit.cn;
+        }
+        if ('dn' in unit) {
+          let dn = unit.dn.split(",");
+          if (dn.length == 5) {
+            // dn[2] = 'ou=associations'
+            unitNameLevel2 = dn[2].split("=")[1];
+          }
+        }
+
+        Sites.update(
+          { _id: site._id },
+          { $set: {
+          'unitName': unitName,
+          'unitNameLevel2': unitNameLevel2
+          }},
+        );
+
+        let newSite = Sites.findOne(site._id);
+        console.log(`Site: ${newSite.url} after update => unitName: ${newSite.unitName} UnitNameLevel2: ${newSite.unitNameLevel2}`);
+        
+      });
+    });
+    console.log('All sites updated:', intendedAt);
+  }
+});
+*/

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -5,7 +5,6 @@ import './publications'; // Call meteor publications backend
 import { importData } from './import-data';
 import { AppLogger } from './logger';
 import './indexes';
-import { Sites } from '../imports/api/collections';
 
 // Define lang <html lang="fr" />
 WebApp.addHtmlAttributeHook(() => ({ lang: 'fr' }));
@@ -15,6 +14,7 @@ let importDatas = true;
 if (Meteor.isServer) {
   import './tequila-config';
   import './rest-api';
+  import './cron';
 
   // Setting up logs
   new AppLogger();
@@ -22,61 +22,7 @@ if (Meteor.isServer) {
   if (importDatas) {
     importData();
   }
-
-  SyncedCron.config({
-    collectionName: 'somethingDifferent'
-  });
-
-  SyncedCron.add({
-    name: 'Update unit names',
-    schedule: function(parser) {
-      // Note: epfl-ldap-js cache is 4 hours
-      // Charles François said, "Changes in unit structure are currently only made once a night."
-      return parser.text('every 24 hours');
-    },
-    job: function(intendedAt) {
-      console.log("Update unitName and unitNameLevel2 of each site starting ...");
-      
-      const fullLdapContext = require('epfl-ldap')();
-      fullLdapContext.options.modelsMapper = fullLdapContext.viewModelsMappers.full;
-
-      // Update all sites
-      let sites = Sites.find({}).fetch();
-      sites.forEach(site => {
-
-        fullLdapContext.units.getUnitByUniqueIdentifier(site.unitId, function(err, unit) {
-
-          let unitName = '';
-          let unitNameLevel2 = '';
-
-          if ('cn' in unit) {
-            unitName = unit.cn;
-          }
-          if ('dn' in unit) {
-            let dn = unit.dn.split(",");
-            if (dn.length == 5) {
-              // dn[2] = 'ou=associations'
-              unitNameLevel2 = dn[2].split("=")[1];
-            }
-          }
-
-          Sites.update(
-            { _id: site._id },
-            { $set: {
-            'unitName': unitName,
-            'unitNameLevel2': unitNameLevel2
-            }},
-          );
-
-          let newSite = Sites.findOne(site._id);
-          console.log(`Site: ${newSite.url} after update => unitName: ${newSite.unitName} UnitNameLevel2: ${newSite.unitNameLevel2}`);
-          
-        });
-      });
-      console.log('All sites updated:', intendedAt);
-    }
-  });
-
+  
   Meteor.startup(function () {
     // code to run on server at startup
     SyncedCron.start();


### PR DESCRIPTION
1. Un site peut être lié à N professeurs. Nous avons fait le choix de stocker le sciper mais aussi le nom du professeur. Il faut donc mettre à jour régulièrement le nom des professeurs par exemple en interrogeant le LDAP. Maintenant qu'un mécanisme de cron existe dans wp-veritas, on supprime le bouton qui permettait de mettre à jour manuellement les professeurs au profit du cron.

2. Lorsqu'un utilisateur édite un site pour modifier l'unit ID, il faut que le nom de l'unité et le nom de l'unité niveau 2 soient mis à jour automatiquement. Actuellement, c'était mis à jour par le cron pendant la nuit.

3. Ajout de la catégorie dans l'export csv 