### PR TITLE
Improve validation fields when site is no wpInfra

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.4'
+wp_veritas_image_version: '1.3.5'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"

--- a/app/imports/api/methods.js
+++ b/app/imports/api/methods.js
@@ -489,8 +489,11 @@ Meteor.methods({
       site.professors = [];
     }
 
-    sitesSchema.validate(site);
-
+    if (site.wpInfra) {
+      sitesSchema.validate(site);
+    } else {
+      sitesWPInfraOutsideSchema.validate(site);
+    }
     site = prepareUpdateInsert(site, 'update');
 
     const { unitName, unitNameLevel2 } = getUnitNames(site.unitId);

--- a/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
+++ b/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
@@ -53,18 +53,14 @@ export const sitesWPInfraOutsideSchema = new SimpleSchema({
   theme: {
       type: String,
       label: "Thème",
-      optional: false,
+      optional: true,
       max: 100,
       min: 3,
   },
   languages: {
       type: Array,
       label: "Langues",
-      custom: function () {
-          if (this.value.length === 0) {
-              return "required";
-          }
-      },
+      optional: true,
   },
   'languages.$': {
       type: String,

--- a/app/imports/ui/components/CustomFields.jsx
+++ b/app/imports/ui/components/CustomFields.jsx
@@ -76,9 +76,14 @@ export const CustomSingleCheckbox = ({ field, form, ...props }) => {
 }
 
 export const CustomCheckbox = ({ field, form, ...props }) => {
+  let disabled = null;
+  if (props.disabled) {
+    disabled = 'disabled';
+  }
   return (
     <div className="form-group form-check form-check-inline">
       <input 
+        { ...disabled }
         { ...field } 
         { ...props } 
         checked={form.values.languages && form.values.languages.includes(field.value)} 

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.4</div>
+                  <div className="dropdown-item">Version 1.3.5</div>
                 </div>
               </li>
               : null}

--- a/app/imports/ui/components/sites/Add.jsx
+++ b/app/imports/ui/components/sites/Add.jsx
@@ -28,7 +28,13 @@ class Add extends Component {
     if (event.target.checked === false) {
       values.openshiftEnv = "-- pas de sélection --";
       values.category = "-- pas de sélection --";
+      values.theme = "-- pas de sélection --";
       values.unitId = "";
+      values.languages = [];
+    } else {
+      values.openshiftEnv = "www";
+      values.category = "GeneralPublic";
+      values.theme = "wp-theme-2018";
     }
   }
 
@@ -226,7 +232,9 @@ class Add extends Component {
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}}
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}}
-                  label="Thème" name="theme" component={ CustomSelect } >
+                  label="Thème" name="theme" component={ CustomSelect }
+                  disabled = { values.wpInfra === false }
+                  >
                   <option key="blank" value="blank">{ emptyValue }</option>
                   {this.props.themes.map( (theme, index) => (
                   <option key={theme._id} value={theme.name}>{theme.name}</option>
@@ -239,31 +247,44 @@ class Add extends Component {
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
                   label="Français" name="languages" type="checkbox" value="fr" 
-                  component={ CustomCheckbox } />
+                  component={ CustomCheckbox } 
+                  disabled = { values.wpInfra === false } />
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
-                  label="Anglais" name="languages" type="checkbox" value="en" component={ CustomCheckbox } />
+                  label="Anglais" name="languages" type="checkbox" value="en" 
+                  component={ CustomCheckbox } 
+                  disabled = { values.wpInfra === false } />
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
-                  label="Allemand" name="languages" type="checkbox" value="de" component={ CustomCheckbox } />
+                  label="Allemand" name="languages" type="checkbox" value="de" 
+                  component={ CustomCheckbox } 
+                  disabled = { values.wpInfra === false } />
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
-                  label="Italien" name="languages" type="checkbox" value="it" component={ CustomCheckbox } />
+                  label="Italien" name="languages" type="checkbox" value="it" 
+                  component={ CustomCheckbox }
+                  disabled = { values.wpInfra === false } />
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
-                  label="Espagnol" name="languages" type="checkbox" value="es" component={ CustomCheckbox } />
+                  label="Espagnol" name="languages" type="checkbox" value="es" 
+                  component={ CustomCheckbox }
+                  disabled = { values.wpInfra === false } />
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
-                  label="Grec" name="languages" type="checkbox" value="el" component={ CustomCheckbox } />
+                  label="Grec" name="languages" type="checkbox" value="el" 
+                  component={ CustomCheckbox }
+                  disabled = { values.wpInfra === false } />
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}} 
-                  label="Roumain" name="languages" type="checkbox" value="ro" component={ CustomCheckbox } />
+                  label="Roumain" name="languages" type="checkbox" value="ro" 
+                  component={ CustomCheckbox }
+                  disabled = { values.wpInfra === false } />
                 <ErrorMessage name="languages" component={ CustomError } />
 
                 <Field

--- a/app/imports/ui/components/sites/Add.jsx
+++ b/app/imports/ui/components/sites/Add.jsx
@@ -209,7 +209,9 @@ class Add extends Component {
                   name="openshiftEnv"
                   component={ CustomSelect }
                   disabled = { values.wpInfra === false } >
+                  { values.wpInfra === false ?
                   <option key="blank" value="blank">{ emptyValue }</option>
+                  : null }
                   {this.props.openshiftenvs.map( (env, index) => (
                   <option key={env._id} value={env.name}>{env.name}</option>
                   ))}
@@ -222,7 +224,9 @@ class Add extends Component {
                   label="Catégorie" name="category" component={ CustomSelect }
                   disabled = { values.wpInfra === false }
                   >
+                  { values.wpInfra === false ?
                   <option key="blank" value="blank">{ emptyValue }</option>
+                  : null }
                   {this.props.categories.map( (category, index) => (
                   <option key={category._id} value={category.name}>{category.name}</option>
                   ))}
@@ -235,7 +239,9 @@ class Add extends Component {
                   label="Thème" name="theme" component={ CustomSelect }
                   disabled = { values.wpInfra === false }
                   >
+                  { values.wpInfra === false ?
                   <option key="blank" value="blank">{ emptyValue }</option>
+                  : null }
                   {this.props.themes.map( (theme, index) => (
                   <option key={theme._id} value={theme.name}>{theme.name}</option>
                   ))}


### PR DESCRIPTION
Amélioration de la validation des champs dans le cas d'un site non infra VPSI. 
Certains champs comme Thème et langue sont maintenant désactivés.

De plus lorsque l'on coche le champ wpInfra : 
- les valeurs par défaut sont définies dans les différents champs.
- la valeur "-- pas de sélection --" n'est pas présente dans les listes déroulantes

