### PR TITLE
Clean datas to no wp infrs sites + run cron only for wpInfra sites

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.5'
+wp_veritas_image_version: '1.3.8'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.8'
+wp_veritas_image_version: '1.3.10'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"

--- a/app/imports/api/methods.js
+++ b/app/imports/api/methods.js
@@ -355,8 +355,6 @@ Meteor.methods({
     site = prepareUpdateInsert(site, 'insert');
 
     const { unitName, unitNameLevel2 } = getUnitNames(site.unitId);
-    console.log('Insert new site with unitName: ', unitName);
-    console.log('Insert new site with unitNameLevel2:', unitNameLevel2);
 
     let siteDocument = {
       url: site.url,
@@ -389,7 +387,7 @@ Meteor.methods({
       this.userId
     );
 
-    return newSiteId;
+    return newSite;
   },
 
   associateProfessorsToSite(site, professors) {
@@ -497,8 +495,6 @@ Meteor.methods({
     site = prepareUpdateInsert(site, 'update');
 
     const { unitName, unitNameLevel2 } = getUnitNames(site.unitId);
-    console.log('Insert new site with unitName: ', unitName);
-    console.log('Insert new site with unitNameLevel2:', unitNameLevel2);
 
     let siteDocument = {
       url: site.url,
@@ -536,7 +532,7 @@ Meteor.methods({
       this.userId
     );
 
-    return site._id;
+    return updatedSite;
   },
     
   removeSite(siteId){

--- a/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
+++ b/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
@@ -40,22 +40,16 @@ export const sitesWPInfraOutsideSchema = new SimpleSchema({
       type: String,
       label: "Environnement openshift",
       optional: false,
-      max: 100,
-      min: 3,
   },
   category: {
       type: String,
       label: "Catégorie",
       optional: false,
-      max: 100,
-      min: 3,
   }, 
   theme: {
       type: String,
       label: "Thème",
       optional: true,
-      max: 100,
-      min: 3,
   },
   languages: {
       type: Array,

--- a/app/imports/ui/components/CustomFields.jsx
+++ b/app/imports/ui/components/CustomFields.jsx
@@ -40,23 +40,22 @@ export const CustomTextarea = ({ field, form: { errors }, ...props}) => {
 }
 
 export const CustomSelect = ({ field, form, ...props }) => {
-  let cssClassName;
-  if (field.name == 'role') {
-    cssClassName = 'form-group float-left px-2 mb-0';
-  } else {
-    cssClassName = 'form-group';
-  }
-  let disabled = null;
+
+  let disabled;
   if (props.disabled) {
     disabled = 'disabled';
   }
+
   return (
-    <div className={cssClassName}>
+    <div className="form-group">
       { props.label ? (<label>{ props.label }</label>) : null }
-      <select { ...disabled }
+      <select 
+        disabled={disabled}
         { ...field }
-        { ...props }
-        className="form-control mt-0" />
+        className="form-control mt-0"
+        >
+        { props.children }
+      </select>
     </div>
   )
 }

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.8</div>
+                  <div className="dropdown-item">Version 1.3.10</div>
                 </div>
               </li>
               : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.5</div>
+                  <div className="dropdown-item">Version 1.3.8</div>
                 </div>
               </li>
               : null}

--- a/app/imports/ui/components/sites/Add.jsx
+++ b/app/imports/ui/components/sites/Add.jsx
@@ -26,9 +26,9 @@ class Add extends Component {
 
   updateFields = (event, values) => {
     if (event.target.checked === false) {
-      values.openshiftEnv = "-- pas de sélection --";
-      values.category = "-- pas de sélection --";
-      values.theme = "-- pas de sélection --";
+      values.openshiftEnv = "";
+      values.category = "";
+      values.theme = "";
       values.unitId = "";
       values.languages = [];
     } else {
@@ -139,7 +139,6 @@ class Add extends Component {
       content = <Loading />
     } else {
       
-      const emptyValue = "-- pas de sélection --";
       let msgAddSuccess = (
         <div className="alert alert-success" role="alert">
           Le nouveau site a été ajouté avec succès ! 
@@ -210,10 +209,10 @@ class Add extends Component {
                   component={ CustomSelect }
                   disabled = { values.wpInfra === false } >
                   { values.wpInfra === false ?
-                  <option key="blank" value="blank">{ emptyValue }</option>
+                  <option key="blank" value="blank" label="" />
                   : null }
                   {this.props.openshiftenvs.map( (env, index) => (
-                  <option key={env._id} value={env.name}>{env.name}</option>
+                  <option key={env._id} value={env.name} label={env.name} />
                   ))}
                 </Field>
                 <ErrorMessage name="openshiftEnv" component={ CustomError } />
@@ -221,33 +220,38 @@ class Add extends Component {
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}}
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}}
-                  label="Catégorie" name="category" component={ CustomSelect }
+                  label="Catégorie"
+                  name="category"
+                  component={ CustomSelect }
                   disabled = { values.wpInfra === false }
                   >
                   { values.wpInfra === false ?
-                  <option key="blank" value="blank">{ emptyValue }</option>
+                  <option key="blank" value="blank" label="" />
                   : null }
                   {this.props.categories.map( (category, index) => (
-                  <option key={category._id} value={category.name}>{category.name}</option>
+                  <option key={category._id} value={category.name} label={category.name} />
                   ))}
                 </Field>
                 <ErrorMessage name="category" component={ CustomError } />
 
                 <Field 
-                  onChange={e => { handleChange(e); this.updateUserMsg();}}
-                  onBlur={e => { handleBlur(e); this.updateUserMsg();}}
-                  label="Thème" name="theme" component={ CustomSelect }
+                  onChange={e => { handleChange(e); this.updateUserMsg(); }}
+                  onBlur={e => { handleBlur(e); this.updateUserMsg(); }}
+                  label="Thème"
+                  name="theme"
+                  component={ CustomSelect }
                   disabled = { values.wpInfra === false }
                   >
                   { values.wpInfra === false ?
-                  <option key="blank" value="blank">{ emptyValue }</option>
+                  <option key="blank" value="blank" label="" />
                   : null }
                   {this.props.themes.map( (theme, index) => (
-                  <option key={theme._id} value={theme.name}>{theme.name}</option>
+                  <option key={theme._id} value={theme.name} label={theme.name} />
                   ))}
                 </Field>
+
                 <ErrorMessage name="theme" component={ CustomError } />
-                
+
                 <h6>Langues</h6>                  
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 

--- a/app/imports/ui/components/sites/List.jsx
+++ b/app/imports/ui/components/sites/List.jsx
@@ -11,7 +11,7 @@ const Cells = (props) => (
         <th scope="row">{ index+1 }</th>
         <td><a href={ site.url } target="_blank">{ site.url }</a></td>
         <td >{ site.getWpInfra() }</td>
-        <td >{ site.openshiftEnv === '-- pas de sélection --' ? '' :  site.openshiftEnv }</td>
+        <td >{ site.openshiftEnv }</td>
         <td >
           <Link className="mr-2" to={ `/edit/${ site._id }` }>
             <button type="button" style={ {marginBottom: "3px"} } className="btn btn-outline-primary">Éditer</button>
@@ -100,6 +100,7 @@ class List extends Component {
         fields: [
           "_id",
           "url",
+          "wpInfra",
           "title",
           "tagline",
           "openshiftEnv",

--- a/app/imports/ui/components/sites/List.jsx
+++ b/app/imports/ui/components/sites/List.jsx
@@ -11,7 +11,7 @@ const Cells = (props) => (
         <th scope="row">{ index+1 }</th>
         <td><a href={ site.url } target="_blank">{ site.url }</a></td>
         <td >{ site.getWpInfra() }</td>
-        <td >{ site.openshiftEnv }</td>
+        <td >{ site.openshiftEnv === '-- pas de sélection --' ? '' :  site.openshiftEnv }</td>
         <td >
           <Link className="mr-2" to={ `/edit/${ site._id }` }>
             <button type="button" style={ {marginBottom: "3px"} } className="btn btn-outline-primary">Éditer</button>

--- a/app/server/cron.js
+++ b/app/server/cron.js
@@ -48,34 +48,38 @@ SyncedCron.add({
     let sites = Sites.find({}).fetch();
     sites.forEach(site => {
 
-      fullLdapContext.units.getUnitByUniqueIdentifier(site.unitId, function(err, unit) {
+      if ('wpInfra' in site && site.wpInfra) {
 
-        let unitName = '';
-        let unitNameLevel2 = '';
+        fullLdapContext.units.getUnitByUniqueIdentifier(site.unitId, function(err, unit) {
 
-        if ('cn' in unit) {
-          unitName = unit.cn;
-        }
-        if ('dn' in unit) {
-          let dn = unit.dn.split(",");
-          if (dn.length == 5) {
-            // dn[2] = 'ou=associations'
-            unitNameLevel2 = dn[2].split("=")[1];
+          let unitName = '';
+          let unitNameLevel2 = '';
+
+          if ('cn' in unit) {
+            unitName = unit.cn;
           }
-        }
+          if ('dn' in unit) {
+            let dn = unit.dn.split(",");
+            if (dn.length == 5) {
+              // dn[2] = 'ou=associations'
+              unitNameLevel2 = dn[2].split("=")[1];
+            }
+          }
 
-        Sites.update(
-          { _id: site._id },
-          { $set: {
-          'unitName': unitName,
-          'unitNameLevel2': unitNameLevel2
-          }},
-        );
+          Sites.update(
+            { _id: site._id },
+            { $set: {
+            'unitName': unitName,
+            'unitNameLevel2': unitNameLevel2
+            }},
+          );
 
-        let newSite = Sites.findOne(site._id);
-        console.log(`Site: ${newSite.url} after update => unitName: ${newSite.unitName} UnitNameLevel2: ${newSite.unitNameLevel2}`);
+          let newSite = Sites.findOne(site._id);
+          console.log(`Site: ${newSite.url} after update => unitName: ${newSite.unitName} UnitNameLevel2: ${newSite.unitNameLevel2}`);
         
-      });
+        });
+        
+      }
     });
     console.log('All sites updated:', intendedAt);
   }

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -103,6 +103,33 @@ deleteUnusedFields = () => {
 
 }
 
+cleanNoWPInfraSites = () => {
+
+  let sites = Sites.find({ wpInfra: false}).fetch();
+
+  sites.forEach(site => {
+
+    console.log(`Site ${ site.url }`);
+    console.log("Site avant :", site);
+    
+    let siteDocument = {
+      openshiftEnv : "-- pas de sélection --",
+      category : "-- pas de sélection --",
+      theme : "-- pas de sélection --",
+      languages : [],
+      unitId : '',
+    }
+
+    Sites.update(
+      { _id: site._id }, 
+      { $set: siteDocument }
+    );
+
+    let siteAfter = Sites.findOne({_id: site._id});
+    console.log("Site après : ", siteAfter); 
+  })
+}
+
 importData = () => {
   
   const absoluteUrl = Meteor.absoluteUrl();
@@ -111,6 +138,8 @@ importData = () => {
     absoluteUrl.startsWith('https://wp-veritas.128.178.222.83.nip.io/')) {
     loadTestData();
   }
+
+  cleanNoWPInfraSites();
     
 }
 

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -113,9 +113,9 @@ cleanNoWPInfraSites = () => {
     console.log("Site avant :", site);
     
     let siteDocument = {
-      openshiftEnv : "-- pas de sélection --",
-      category : "-- pas de sélection --",
-      theme : "-- pas de sélection --",
+      openshiftEnv : "",
+      category : "",
+      theme : "",
       languages : [],
       unitId : '',
     }

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -139,8 +139,6 @@ importData = () => {
     loadTestData();
   }
 
-  cleanNoWPInfraSites();
-    
 }
 
 export { importData }

--- a/app/server/publications.js
+++ b/app/server/publications.js
@@ -13,14 +13,9 @@ Meteor.publish('sites.list', function() {
     ];
 });
 
-Meteor.publish('site.single', function(siteId) {
-
-    check(siteId, String);
-    
-    let siteCursor = Sites.find({_id: siteId});
-    return [
-        siteCursor,
-    ]; 
+Meteor.publish('siteById', function (siteId) {
+  check(siteId, String);
+  return Sites.find({ _id: siteId });
 });
 
 Meteor.publish('openshiftEnv.list', function() {


### PR DESCRIPTION
1. Une des tâches du cron est de mettre à jour le nom des unités à partir de l'unit id.
Les sites ne faisant pas partis de l'infra WP VPSI n'ont pas d'unit ID donc cette PR a pour but de les exclure de cette tâche de cron.

2. Mises à jour des sites ne faisant pas partis de l'infra WP VPSI pour que les champs theme, openshiftenv, category, languages ou encore unitId aient les "bonnes" valeurs

3. Le champ unitName dépend du champ unitId. Lorsque l'utilisateur édite les informations d'un site et modifie l'unitId, le champ unitName est modifié instantanément après le submit.