### PR TITLE
Rename slug field to userExperienceUniqueLabel

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.10'
+wp_veritas_image_version: '1.3.11'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"

--- a/app/imports/api/methods.js
+++ b/app/imports/api/methods.js
@@ -22,8 +22,8 @@ import { AppLogger } from '../../server/logger';
 
 function prepareUpdateInsert(site, action) {
 
-  if (site.slug == undefined) {
-    site.slug = '';
+  if (site.userExperienceUniqueLabel == undefined) {
+    site.userExperienceUniqueLabel = '';
   }
 
   // Delete "/" at the end of URL 
@@ -32,7 +32,7 @@ function prepareUpdateInsert(site, action) {
     site.url = url.slice(0, -1);
   }
   
-  // Check if url is unique and if slug is unique
+  // Check if url is unique and if userExperienceUniqueLabel is unique
   // TODO: Move this code to SimpleSchema custom validation function
   if (action === 'update') {
     let sites = Sites.find({url:site.url});
@@ -43,13 +43,13 @@ function prepareUpdateInsert(site, action) {
         throwMeteorError('url', 'Cette URL existe déjà !');
       }
     }
-    if (site.slug != '') {
-      let sitesBySlug = Sites.find({slug:site.slug});
-      if (sitesBySlug.count() > 1) {
-        throwMeteorError('slug', 'Ce slug existe déjà !');
-      } else if (sitesBySlug.count() == 1) {
-        if (sitesBySlug.fetch()[0]._id != site._id) {
-          throwMeteorError('slug', 'Ce slug existe déjà !');
+    if (site.userExperienceUniqueLabel != '') {
+      let sitesByUXUniqueLabel = Sites.find({userExperienceUniqueLabel:site.userExperienceUniqueLabel});
+      if (sitesByUXUniqueLabel.count() > 1) {
+        throwMeteorError('userExperienceUniqueLabel', 'Ce label existe déjà !');
+      } else if (sitesByUXUniqueLabel.count() == 1) {
+        if (sitesByUXUniqueLabel.fetch()[0]._id != site._id) {
+          throwMeteorError('userExperienceUniqueLabel', 'Ce label existe déjà !');
         }
       }
     }
@@ -58,8 +58,8 @@ function prepareUpdateInsert(site, action) {
       throwMeteorError('url', 'Cette URL existe déjà !');
     }
 
-    if (site.slug != '' && Sites.find({slug:site.slug}).count() > 0) {
-      throwMeteorError('slug', 'Ce slug existe déjà !');
+    if (site.userExperienceUniqueLabel != '' && Sites.find({userExperienceUniqueLabel:site.userExperienceUniqueLabel}).count() > 0) {
+      throwMeteorError('userExperienceUniqueLabel', 'Ce label existe déjà !');
     }
   }
 
@@ -358,7 +358,6 @@ Meteor.methods({
 
     let siteDocument = {
       url: site.url,
-      slug: site.slug,
       tagline: site.tagline,
       title: site.title,
       openshiftEnv: site.openshiftEnv,
@@ -372,6 +371,7 @@ Meteor.methods({
       comment: site.comment,
       createdDate: new Date(),
       userExperience: site.userExperience,
+      userExperienceUniqueLabel: site.userExperienceUniqueLabel,
       tags: site.tags,
       professors: site.professors,
       wpInfra: site.wpInfra,
@@ -498,7 +498,6 @@ Meteor.methods({
 
     let siteDocument = {
       url: site.url,
-      slug: site.slug,
       tagline: site.tagline,
       title: site.title,
       openshiftEnv: site.openshiftEnv,
@@ -512,6 +511,7 @@ Meteor.methods({
       comment: site.comment,
       createdDate: site.createdDate,
       userExperience: site.userExperience,
+      userExperienceUniqueLabel: site.userExperienceUniqueLabel,
       tags: site.tags,
       professors: site.professors,
       wpInfra: site.wpInfra,

--- a/app/imports/api/schemas/sitesSchema.js
+++ b/app/imports/api/schemas/sitesSchema.js
@@ -16,12 +16,6 @@ export const sitesSchema = new SimpleSchema({
       custom: isRequired,
       regEx: SimpleSchema.RegEx.Url,
   },
-  slug: {
-      type: String,
-      label: "Slug",
-      optional: true,
-      max: 50,
-  },
   tagline: {
       type: String,
       label: "Tagline",
@@ -110,6 +104,16 @@ export const sitesSchema = new SimpleSchema({
   userExperience: {
       type: Boolean,
       optional: true,
+  },
+  userExperienceUniqueLabel: {
+    type: String,
+    optional: true,
+    max: 50,
+  },
+  slug: {
+    type: String,
+    optional: true,
+    max: 50,
   },
   professors: {
     type: Array,

--- a/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
+++ b/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
@@ -16,12 +16,6 @@ export const sitesWPInfraOutsideSchema = new SimpleSchema({
       custom: isRequired,
       regEx: SimpleSchema.RegEx.Url,
   },
-  slug: {
-      type: String,
-      label: "Slug",
-      optional: true,
-      max: 50,
-  },
   tagline: {
       type: String,
       label: "Tagline",
@@ -98,6 +92,16 @@ export const sitesWPInfraOutsideSchema = new SimpleSchema({
   userExperience: {
       type: Boolean,
       optional: true,
+  },
+  userExperienceUniqueLabel: {
+    type: String,
+    optional: true,
+    max: 50,
+  },
+  slug: {
+    type: String,
+    optional: true,
+    max: 50,
   },
   professors: {
     type: Array,

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.10</div>
+                  <div className="dropdown-item">Version 1.3.11</div>
                 </div>
               </li>
               : null}

--- a/app/imports/ui/components/sites/Add.jsx
+++ b/app/imports/ui/components/sites/Add.jsx
@@ -65,6 +65,7 @@ class Add extends Component {
       values, 
       (errors, site) => {
         if (errors) {
+          console.log(errors);
           let formErrors = {};
           errors.details.forEach(function(error) {
             formErrors[error.name] = error.message;                        
@@ -89,7 +90,7 @@ class Add extends Component {
     if (this.state.action == 'add') {
       initialValues = { 
         url: '',
-        slug: '',
+        userExperienceUniqueLabel: '',
         tagline: '', 
         title: '', 
         openshiftEnv: 'www', 
@@ -339,9 +340,9 @@ class Add extends Component {
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 
                   onBlur={e => { handleBlur(e); this.updateUserMsg();}}  
                   onBlur={this.updateUserMsg}
-                  placeholder="" label="Slug pour le ressenti" name="slug" type="text"
+                  placeholder="Libellé doit être unique" label="Libellé pour le ressenti" name="userExperienceUniqueLabel" type="text"
                   component={ CustomInput } />
-                <ErrorMessage name="slug" component={ CustomError } />
+                <ErrorMessage name="userExperienceUniqueLabel" component={ CustomError } />
                 
                 <Field 
                   onChange={e => { handleChange(e); this.updateUserMsg();}} 

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -62,7 +62,7 @@ loadTestData = () => {
       snowNumber: '',
       comment: '',
       userExperience: false,
-      slug: '',
+      userExperienceUniqueLabel: '',
       professors: [],
       tags: [],
     }
@@ -130,15 +130,68 @@ cleanNoWPInfraSites = () => {
   })
 }
 
-importData = () => {
+renameSlugToUserExperienceUniqueLabel = () => {
+
+  let sites = Sites.find({}).fetch();
+
+  sites.forEach(site => {
+
+    console.log(`Site ${ site.url }`);
+    console.log("Site avant :", site);
+
+    let slug = '';
+    if ("slug" in site && site.slug) {
+      slug = site.slug;
+    } 
   
+    let siteDocument = {
+      userExperienceUniqueLabel: slug,
+    }
+
+    Sites.update(
+      { _id: site._id }, 
+      { $set: siteDocument }
+    );
+
+    let siteAfter = Sites.findOne({_id: site._id});
+    console.log("Site après : ", siteAfter); 
+    
+  });
+
+}
+
+deleteSlug = () => {
+
+  let sites = Sites.find({}).fetch();
+
+  sites.forEach(site => {
+
+    console.log(`Site ${ site.url }`);
+    console.log("Site avant :", site);
+
+    Sites.update(
+      { _id: site._id },
+      { $unset: {
+        'slug': "",
+      }},
+    );
+
+    let siteAfter = Sites.findOne({_id: site._id});
+    console.log("Site après : ", siteAfter); 
+
+  });
+
+}
+
+importData = () => {
   const absoluteUrl = Meteor.absoluteUrl();
   if (
     // absoluteUrl === "http://localhost:3000/" || 
     absoluteUrl.startsWith('https://wp-veritas.128.178.222.83.nip.io/')) {
     loadTestData();
   }
-
+  renameSlugToUserExperienceUniqueLabel();
+  // deleteSlug();
 }
 
 export { importData }


### PR DESCRIPTION
Cette PR a pour but de renommer le champ 'slug' utiliser pour le "ressenti utilisateur" en userExperienceUniqueLabel. 

Tester : 
- si l'ajout, l'édition fonctionne encore :
- si la validation du champ unique
- si API REST ok 
- si Migration ok 
