### PR TITLE
Update ansible deployment

### DIFF
--- a/ansible/roles/epfl.wp-veritas/tasks/secrets.yml
+++ b/ansible/roles/epfl.wp-veritas/tasks/secrets.yml
@@ -7,7 +7,7 @@
     content: |
       apiVersion: v1
       stringData:
-        mongo-url: 'mongodb://{{ wp_veritas_db_user }}:{{ wp_veritas_db_password }}@mongodb-svc-1.epfl.ch/{{ wp_veritas_db_name }}'
+        mongo-url: 'mongodb://{{ wp_veritas_db_user }}:{{ wp_veritas_db_password }}@{{ db_host }}.epfl.ch/{{ wp_veritas_db_name }}'
         meteor-settings: '{{ lookup("env", "METEOR_SETTINGS") }}' # MOVE this to KEYBASE
       kind: Secret
       metadata:

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -8,7 +8,8 @@ wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace ==
 wp_veritas_deploy_name: wp-veritas
 wp_veritas_image_version: '1.3.11'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
-wp_veritas_db_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
-wp_veritas_db_user: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
+wp_veritas_db_name: wp-veritas
+wp_veritas_db_user: wp-veritas
 wp_veritas_db_password: "{{ lookup('env','WP_VERITAS_DB_PASSWORD_PROD') if openshift_namespace == 'wwp' else lookup('env','WP_VERITAS_DB_PASSWORD_TEST') }}"
 meteor_settings_env: " {{ lookup('env','METEOR_SETTINGS') }}"
+db_host: "{{ 'mongodb-svc-1' if openshift_namespace == 'wwp' else 'test-mongodb-svc-1' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.3.11'
+wp_veritas_image_version: '1.3.12'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: wp-veritas
 wp_veritas_db_user: wp-veritas

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -59,7 +59,7 @@ class Header extends Component {
                 <div className="dropdown-menu">
                   <NavLink className="dropdown-item" exact to="/admin" activeClassName="active">Admin</NavLink>
                   <NavLink className="dropdown-item" to="/admin/log/list" activeClassName="active">Voir les logs</NavLink>
-                  <div className="dropdown-item">Version 1.3.11</div>
+                  <div className="dropdown-item">Version 1.3.12</div>
                 </div>
               </li>
               : null}

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -185,13 +185,15 @@ deleteSlug = () => {
 
 importData = () => {
   const absoluteUrl = Meteor.absoluteUrl();
+  /*
   if (
     // absoluteUrl === "http://localhost:3000/" || 
     absoluteUrl.startsWith('https://wp-veritas.128.178.222.83.nip.io/')) {
     loadTestData();
   }
-  renameSlugToUserExperienceUniqueLabel();
-  // deleteSlug();
+  */
+  
+  deleteSlug();
 }
 
 export { importData }


### PR DESCRIPTION
La base de données de test de wp-veritas a été déplacé de l'environnement de prod vers l'environnement de test chez camptocamp.

Ce qui a changé :
Nom de la DB est maintenant **wp-veritas** (avant: wp-veritas-test)
Nom du username est maintenant **wp-veritas** (avant: wp-veritas-test)
Nom du host est maintenant **test-mongodb-svc-1.epfl.ch** (avant mondb-svc-1.epfl.ch)

Il faut donc adapter la config en conséquence.