### PR TITLE
[feature] Docker dev support

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,33 @@
+#
+# This docker file aims to provide a simple environment for development purpose.
+#
+# Build: docker-compose -f docker-compose-dev.yml build
+# Deploy: docker-compose -f docker-compose-dev.yml up
+# Exec: docker exec -it --user root wp-veritas_meteor bash
+# Run: docker run -it --entrypoint bash --rm wp-veritas_app -c "meteor --version"
+
+FROM node:12-buster-slim
+LABEL maintainer="IDEV-FSD <idev-fsd@groupes.epfl.ch>"
+
+ENV LC_ALL=POSIX
+ENV METEOR_VERSION=1.10.2
+ENV METEOR_ALLOW_SUPERUSER=1
+
+RUN apt-get -yqq update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yqq install \
+        curl \
+        g++ \
+        make \
+        mongo-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl "https://install.meteor.com/?release=${METEOR_VERSION}" | /bin/sh
+ENV PATH=$PATH:/root/.meteor
+
+RUN meteor --version
+
+WORKDIR /app
+VOLUME /app
+
+EXPOSE 3000
+CMD [ "meteor" ]

--- a/README.md
+++ b/README.md
@@ -4,13 +4,39 @@
 
 Cette application a pour but de stocker la source de vérité des sites WordPress de l'EPFL.
 
+<!-- TOC titleSize:2 tabSpaces:3 depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 skip:1 title:1 charForUnorderedList:* -->
+## Table of Contents
+* [Local](#local)
+   * [Lancer l'application en local](#lancer-lapplication-en-local)
+   * [Lancer l'application via docker](#lancer-lapplication-via-docker)
+   * [Lancer l'application via docker pour le développment](#lancer-lapplication-via-docker-pour-le-développment)
+      * [Commandes et informations supplémentaires](#commandes-et-informations-supplémentaires)
+* [veritas-cli](#veritas-cli)
+* [Déploiement](#déploiement)
+   * [Déployer une nouvelle version sur l'environnement de test d'openshift](#déployer-une-nouvelle-version-sur-lenvironnement-de-test-dopenshift)
+   * [Déployer une nouvelle version sur l'environnement de prod d'openshift](#déployer-une-nouvelle-version-sur-lenvironnement-de-prod-dopenshift)
+   * [Procédure de mise en prod](#procédure-de-mise-en-prod)
+   * [Référence sur Dockerhub](#référence-sur-dockerhub)
+* [Manipulation des données](#manipulation-des-données)
+   * [Importer les informations de la source de vérité](#importer-les-informations-de-la-source-de-vérité)
+   * [Si vous avez besoin de supprimer tous les sites avant de relancer l'import des données](#si-vous-avez-besoin-de-supprimer-tous-les-sites-avant-de-relancer-limport-des-données)
+* [Autentification Tequila et rôles](#autentification-tequila-et-rôles)
+* [Notes](#notes)
+   * [Mise à jour de l'image](#mise-à-jour-de-limage)
+   * [Comment exécuter les tests](#comment-exécuter-les-tests)
+   * [Mise à jour de paquet alanning:roles](#mise-à-jour-de-paquet-alanningroles)
+<!-- /TOC -->
+
+
+# Local
+
 ## Lancer l'application en local 
 
 Se positionner dans le répertoire app/ et lancer la commande :
 
 `cd app/`
 
-`meteor --settings settings.json`
+`meteor --settings meteor-settings.json`
 
 Ensuite aller à l'adresse http://localhost:3000
 
@@ -22,7 +48,41 @@ Se positionner dans le répertoire racine et faire un : `docker-compose up`
 
 Ensuite aller à l'adresse https://localhost
 
-## Utiliser le CLI
+## Lancer l'application via docker pour le développment
+
+Afin de garantir que l'environnement node, meteor et mongodb soit
+similaire pour tout les développeurs, et pour éviter la gestion de
+version de ces environnements sur l'hôte, il est possible d'utiliser
+[docker-compose-dev.yml](./docker-compose-dev.yml).
+
+  1. Construire l'image docker avec :  
+     `docker-compose -f docker-compose-dev.yml build`
+  1. Lancer l'image docker avec :  
+     `docker-compose -f docker-compose-dev.yml up`
+
+### Commandes et informations supplémentaires
+
+Il est possible de lancer des commandes directement dans le container, 
+par exemple :  
+`docker run -it --entrypoint bash --rm wp-veritas_app -c "meteor --version"`
+
+De même, il est possible de rentrer dans le container avec :  
+`docker exec -it --user root wp-veritas_meteor bash`
+
+Note: la spécification de l'utilisateur root n'est pas nécessaire, mais le
+[docker-compose-dev.yml](./docker-compose-dev.yml) tente de faire matcher
+un utilisateur du système avec celui dans le container. Il se peut que votre
+utilisateur ait l'identificant 1000, ce qui correspond à l'utilisateur "node"
+dans le container. Dans ce cas, les commandes "root" ne fonctionneront pas sans
+spécifier l'utiliser à l'aide de l'option `--user root`.
+
+L'application se trouve dans le dossier `/app` du container. Néanmoins, tous les
+fichiers du projet sont également disponible dans le container, dans le dossier
+`/src`. Cela permet par exemple de tester et d'utiliser `veritas-cli`. Pour ce
+faire, se rendre dans `/src/cli` et suivre les indications ci-dessous.
+
+
+# veritas-cli
 
 Pour installer le CLI en local, il faut:
 - Se placer dans le répetoire `cli/`
@@ -45,6 +105,9 @@ Commands:
   restore-test-db      Restore the test MongoDB on local MongoDB
   restore-prod-db      Restore the production MongoDB on local MongoDB
 ```
+
+
+# Déploiement
 
 ## Déployer une nouvelle version sur l'environnement de test d'openshift
 
@@ -71,9 +134,7 @@ On pousse l'image dans dockerhub
 
 Ensuite on doit modifier la référence à cette image dans le déploiment openshift en éditant le fichier ansible/main.yml.
 
-`
-wp_veritas_image_version: '0.1.10'
-`
+`wp_veritas_image_version: '0.1.10'`
 
 `cd ansible/`
 
@@ -83,11 +144,21 @@ wp_veritas_image_version: '0.1.10'
 
 `ansible-playbook playbook.yml -i hosts-prod`
 
-## Dockerhub
+## Procédure de mise en prod
+Lancer le déploiement => ce qui va exécuter `updateRoles` qui supprime la
+collection `roles` et qui supprime l'attribut roles dans chaque user. La
+collection est re-créée par les fixtures.
+
+## Référence sur Dockerhub
 
 https://hub.docker.com/repository/docker/epflsi/wp-veritas
 
-## Importer les information de la source de vérité
+
+# Manipulation des données
+
+## Importer les informations de la source de vérité
+
+(Obsolète, utiliser veritas-cli)
 
 Vous devez être positionné dans le répertoire app/ et avoir lancé l'application.
 
@@ -103,15 +174,18 @@ Vous devez être positionné dans le répertoire app/ et avoir lancé l'applicat
 
 `db.sites.deleteMany({})`
 
-docker push epflsi/wp-veritas:latest
+`docker push epflsi/wp-veritas:latest`
 
-## Autentification Tequila et rôle
+# Autentification Tequila et rôles
 
 - Pour se connecter à l'application, il se faut s'authentifier Tequila.
 - Pour obtenir le rôle 'admin' il faut appartenir au groupe 'wp-veritas-admins' de l'application groups.epfl.ch
 - Pour obtenir le rôle 'editor' il faut appartenir au groupe 'wp-veritas-editors' de l'application groups.epfl.ch
 
 
+# Notes
+
+## Mise à jour de l'image
 ATTENTION :
 Pour mettre à jour l'image avec FROM node:10.19-alpine 
 On a du utiliser node version 10 car avec la 12 on avait un prob avec Fiber 
@@ -124,6 +198,3 @@ TEST_WATCH=1 meteor test --driver-package meteortesting:mocha
 La mise à jour du paquet `alanning:roles` de la version 1 à la version 3 a necessité des changements en DB.
 En effet, il faut supprimer la collection `roles` et la re-créée via le fichier server/fixtures.js
 De plus, le user n'a plus d'attributs roles mais une nouvelle collection `role-assignement`
-
-### procédure de mise en prod
-Lancer le déploiement => ce qui va exécuter `updateRoles` qui supprime la collection `roles` et qui supprime l'attribut roles dans chaque user. La collection est re-créée par les fixtures.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,48 @@
+# This docker-compose file aim to provide a development environement to avoid
+# having version mismatch with the production environement, e.g. meteor or node.
+#
+# It also expose the mongoDB port to facilitate the use of a mongoDB browser 
+# (e.g. robo3t).
+#
+# For the app service, the configuration user 
+# (https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir)
+# attempt to use the same user as the host user, to avoid permssions problems,
+# especially on the /app/.meteor/local folder.
+#
+
+version: '3'
+
+services:
+  app:
+    container_name: wp-veritas_meteor
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    ports:
+      - '80:3000'
+    links:
+      - mongo
+    depends_on:
+      - mongo
+    volumes:
+      - $PWD/app:/app
+      - $PWD:/src
+    user: ${UID:-1000}:${GID:-1000}
+    environment:
+      ROOT_URL: ${APP_ROOT_URL:-http://localhost}
+      MONGO_URL: mongodb://mongo:27017/meteor
+      PORT: 3000
+      METEOR_SETTINGS_FILE: /src/app/meteor-settings.json # See docker/entrypoint.sh
+
+  mongo:
+    container_name: wp-veritas_mongo
+    image: mongo:latest
+    ports: 
+      - '27017:27017'
+    command:
+      - --storageEngine=wiredTiger
+    volumes:
+      - data:/data/db
+
+volumes:
+  data:


### PR DESCRIPTION
One can now use a complete docker environment to develop new feature
for this project, without having to care about installing local version
of node, meteor or mongodb. The project in mounted as a volume in the
container, and the docker-compose-dev.yml try to match the user and
group id to avoid permissions problems.

The meteor service also provide mongo-tools, which means that one can 
use and test the veritas-cli feature inside the container.

Finally, this PR also include some documentation about that in the README file, 
which now have a table of content and some more organized titles — hope this is fine.