### PR TITLE
[validation] validate consistency of fields for inside and subdomains…

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.5.10'
+wp_veritas_image_version: '1.6.0'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: wp-veritas
 wp_veritas_db_user: wp-veritas

--- a/app/imports/api/error.js
+++ b/app/imports/api/error.js
@@ -1,7 +1,18 @@
 
 export function throwMeteorError(fieldName, message) {
-    const ddpError = new Meteor.Error(message);
-    ddpError.error = 'validation-error';
-    ddpError.details = [{name: fieldName, message: message}];
-    throw ddpError;
+  const ddpError = new Meteor.Error(message);
+  ddpError.error = 'validation-error';
+  ddpError.details = [{name: fieldName, message: message}];
+  throw ddpError;
+}
+
+export function throwMeteorErrors(fieldNameList, message) {
+  const ddpError = new Meteor.Error(message);
+  ddpError.error = 'validation-error';
+  errors = [];
+  fieldNameList.forEach(fieldName => {
+      errors.push({name: fieldName, message: message});
+  });
+  ddpError.details = errors;
+  throw ddpError;
 }

--- a/app/imports/api/methods/sites.js
+++ b/app/imports/api/methods/sites.js
@@ -2,7 +2,7 @@ import SimpleSchema from "simpl-schema";
 import { Sites, professorSchema, tagSchema } from "../collections";
 import { sitesSchema } from "../schemas/sitesSchema";
 import { sitesWPInfraOutsideSchema } from "../schemas/sitesWPInfraOutsideSchema";
-import { throwMeteorError } from "../error";
+import { throwMeteorErrors } from "../error";
 import { AppLogger } from "../logger";
 import { rateLimiter } from "./rate-limiting";
 import { VeritasValidatedMethod, Admin, Editor } from "./role";
@@ -97,6 +97,22 @@ function prepareUpdateInsert(site, action) {
   return site;
 }
 
+const validateConsistencyOfFields = (newSite) => {
+  // Check if inside site datas are OK
+  if (newSite.url.includes('inside.epfl.ch') || newSite.openshiftEnv === 'inside' || newSite.category === 'Inside') {
+    if (!(newSite.url.includes('inside.epfl.ch') && newSite.openshiftEnv === 'inside' && newSite.category === 'Inside')) {
+      throwMeteorErrors(["url", "category", "openshiftEnv"], "Site inside: Les champs url, catégorie et environnement OpenShift ne sont pas cohérents");
+    }
+  }
+
+  // Check if subdomains-lite site datas are OK
+  if ((newSite.openshiftEnv === 'subdomains-lite' || newSite.openshiftEnv.startsWith("unm-")) || newSite.theme === 'wp-theme-light') {
+    if (!((newSite.openshiftEnv === 'subdomains-lite' || newSite.openshiftEnv.startsWith("unm-")) && newSite.theme === 'wp-theme-light')) {
+      throwMeteorErrors(["theme", "openshiftEnv"], "Site subdomains-lite: Les champs thème et environnement OpenShift ne sont pas cohérents");
+    }
+  }
+}
+
 const insertSite = new VeritasValidatedMethod({
   name: "insertSite",
   role: Admin,
@@ -106,6 +122,7 @@ const insertSite = new VeritasValidatedMethod({
     } else {
       sitesWPInfraOutsideSchema.validate(newSite);
     }
+    validateConsistencyOfFields(newSite);
   },
   run(newSite) {
     newSite = prepareUpdateInsert(newSite, "insert");
@@ -158,14 +175,19 @@ const updateSite = new VeritasValidatedMethod({
   name: "updateSite",
   role: Admin,
   validate(newSite) {
+
+    // TODO: Ajouter un champ professors: [] à tous les sites qui n'ont pas de prof
     if (!("professors" in newSite)) {
       newSite.professors = [];
     }
+
     if (newSite.wpInfra) {
       sitesSchema.validate(newSite);
     } else {
       sitesWPInfraOutsideSchema.validate(newSite);
     }
+
+    validateConsistencyOfFields(newSite);
   },
   run(newSite) {
     newSite = prepareUpdateInsert(newSite, "update");

--- a/app/imports/ui/components/CustomFields.jsx
+++ b/app/imports/ui/components/CustomFields.jsx
@@ -39,7 +39,7 @@ export const CustomTextarea = ({ field, form: { errors }, ...props}) => {
   )
 }
 
-export const CustomSelect = ({ field, form, ...props }) => {
+export const CustomSelect = ({ field, form: { errors }, ...props }) => {
 
   let disabled;
   if (props.disabled) {
@@ -52,7 +52,7 @@ export const CustomSelect = ({ field, form, ...props }) => {
       <select 
         disabled={disabled}
         { ...field }
-        className="form-control mt-0"
+        className={errors[field.name] ? "is-invalid form-control" : "form-control mt-0"}
         >
         { props.children }
       </select>

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -149,7 +149,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.5.10</div>
+                    <div className="dropdown-item">Version 1.6.0</div>
                   </div>
                 </li>
               ) : null}


### PR DESCRIPTION
Cette PR a pour but de valider la saisie de l'utilisateur pour la création d'un site inside ou subdomains-lite.
- Si on créée un site inside, les champs url catégorie et env openshift doivent être cohérents
- Si on créée un site subdomains-lite, les champs theme et env openshift doivent être cohérents
