### PR TITLE
Feature/improve rest api

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.7.15'
+wp_veritas_image_version: '1.7.16'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: wp-veritas
 wp_veritas_db_user: wp-veritas

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -6,7 +6,7 @@ wp_veritas_route_name: wp-veritas
 wp_veritas_secret_name: "{{ 'wp-veritas' if openshift_namespace == 'wwp' else 'wp-veritas-test' }}"
 wp_veritas_cname: "{{ wp_veritas_app_name + '.epfl.ch' if openshift_namespace == 'wwp' else 'wp-veritas.128.178.222.83.nip.io' }}"
 wp_veritas_deploy_name: wp-veritas
-wp_veritas_image_version: '1.7.16'
+wp_veritas_image_version: '1.7.17'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: wp-veritas
 wp_veritas_db_user: wp-veritas

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -149,7 +149,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.7.15</div>
+                    <div className="dropdown-item">Version 1.7.16</div>
                   </div>
                 </li>
               ) : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -149,7 +149,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.7.16</div>
+                    <div className="dropdown-item">Version 1.7.17</div>
                   </div>
                 </li>
               ) : null}

--- a/app/server/rest-api.js
+++ b/app/server/rest-api.js
@@ -303,4 +303,27 @@ Api.addRoute(
   }
 );
 
+// Maps to: /api/v1/categories/:name/sites
+Api.addRoute(
+  "categories/:name/sites",
+  { authRequired: false },
+  {
+    get: function () {
+      let categoryName;
+      try {
+        categoryName = Categories.findOne({ name: this.urlParams.name }).name;
+      } catch (error) {
+        console.log(error);
+        let msg = `This category "${this.urlParams.name}" is unknown. Use api/v1/categories to list them.`;
+        return APIError("Not found", msg);
+      }
+      return formatSiteCategories(
+        Sites.find({
+          categories: { $elemMatch: { name: categoryName } },
+        }).fetch()
+      );
+    },
+  }
+);
+
 export default Api;

--- a/app/server/rest-api.js
+++ b/app/server/rest-api.js
@@ -13,6 +13,17 @@ let Api = new Restivus({
   version: "v1",
 });
 
+const APIError = (status, message, statusCode = 404) => {
+  return {
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Custom-Header": `${status}: ${message}`,
+    },
+    body: { status, message },
+  };
+};
+
 const isIterable = (obj) => {
   // checks for null and undefined
   if (obj == null) {

--- a/app/server/rest-api.js
+++ b/app/server/rest-api.js
@@ -49,7 +49,8 @@ const formatSiteCategories = (sites) => {
 
 // Maps to: /api/v1/sites
 // and to: /api/v1/sites?site_url=... to get a specific site
-// and to: /api/v1/sites?text=... to search a list of sites from a text with status "created" or "no-wordpress"
+// and to: /api/v1/sites?search_url=... to filter sites based on URL
+// and to: /api/v1/sites?text=... to search a list of sites from a text
 // and to: /api/v1/sites?tags=... to search a list of sites from an array of tags with status "created" or "no-wordpress"
 // and to: /api/v1/sites?tagged=true to retrieve the list of sites with at least a tag with status "created" or "no-wordpress"
 Api.addRoute(
@@ -61,7 +62,15 @@ Api.addRoute(
       var query = this.queryParams;
 
       if (query && this.queryParams.site_url) {
-        return formatSiteCategories(Sites.findOne({ url: this.queryParams.site_url }));
+        return formatSiteCategories(
+          Sites.find({ url: this.queryParams.site_url }).fetch()
+        );
+      } else if (query && this.queryParams.search_url) {
+        return formatSiteCategories(
+          Sites.find({
+            url: { $regex: this.queryParams.search_url, $options: "-i" },
+          }).fetch()
+        );
       } else if (query && (this.queryParams.text || this.queryParams.tags)) {
         if (this.queryParams.tags && !Array.isArray(this.queryParams.tags)) {
           this.queryParams.tags = [this.queryParams.tags];

--- a/app/server/rest-api.js
+++ b/app/server/rest-api.js
@@ -13,17 +13,28 @@ let Api = new Restivus({
   version: "v1",
 });
 
+const isIterable = (obj) => {
+  // checks for null and undefined
+  if (obj == null) {
+    return false;
+  }
+  return typeof obj[Symbol.iterator] === "function";
+};
 
 const formatSiteCategories = (sites) => {
-  for (let site of sites) {
-    if (site.categories) {
-      site.categories = site.categories.map(
-        (category) => category.name
-      );
+  if (isIterable(sites)) {
+    for (let site of sites) {
+      if (site.categories) {
+        site.categories = site.categories.map((category) => category.name);
+      }
+    }
+  } else {
+    if (sites.categories) {
+      sites.categories = sites.categories.map((category) => category.name);
     }
   }
   return sites;
-}
+};
 
 // Maps to: /api/v1/sites
 // and to: /api/v1/sites?site_url=... to get a specific site

--- a/app/server/rest-api.js
+++ b/app/server/rest-api.js
@@ -60,11 +60,12 @@ Api.addRoute(
     get: function () {
       // is that a id request from an url ?
       var query = this.queryParams;
-
       if (query && this.queryParams.site_url) {
-        return formatSiteCategories(
-          Sites.find({ url: this.queryParams.site_url }).fetch()
-        );
+        let siteUrl = this.queryParams.site_url;
+        if (siteUrl.endsWith("/")) {
+          siteUrl = siteUrl.slice(0, -1);
+        }
+        return formatSiteCategories(Sites.findOne({ url: siteUrl }));
       } else if (query && this.queryParams.search_url) {
         return formatSiteCategories(
           Sites.find({


### PR DESCRIPTION
Cette PR a pour but de :
- fixer les issues : #85 #87 
- ajout du filtre search_url pour filter les sites à partir d'un pattern. Exemple : /api/v1/sites/?search_url=dcsl
- le paramètre site_url gère le slash (ou non) à la fin de l'URL
- l'API retourne actuellement un élément seul dans le cas du paramètre site_url. Prochain wagon : l'API retournera une liste d'éléments