### PR TITLE
Ajout du champ 'isDeleted'

### DIFF
--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -16,7 +16,7 @@ wp_veritas_cname: "{{ 'wp-veritas.epfl.ch' if server_name == 'prod' else (
 wp_veritas_deploy_name: "{{ 'wp-veritas' if server_name == 'prod' else ( 
   'wp-veritas-test' if server_name == 'test' else (
   'wp-veritas-dev')) }}"
-wp_veritas_image_version: '1.10.5'
+wp_veritas_image_version: '1.10.6'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"
 wp_veritas_db_user: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -16,7 +16,7 @@ wp_veritas_cname: "{{ 'wp-veritas.epfl.ch' if server_name == 'prod' else (
 wp_veritas_deploy_name: "{{ 'wp-veritas' if server_name == 'prod' else ( 
   'wp-veritas-test' if server_name == 'test' else (
   'wp-veritas-dev')) }}"
-wp_veritas_image_version: '1.10.3'
+wp_veritas_image_version: '1.10.4'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"
 wp_veritas_db_user: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -16,7 +16,7 @@ wp_veritas_cname: "{{ 'wp-veritas.epfl.ch' if server_name == 'prod' else (
 wp_veritas_deploy_name: "{{ 'wp-veritas' if server_name == 'prod' else ( 
   'wp-veritas-test' if server_name == 'test' else (
   'wp-veritas-dev')) }}"
-wp_veritas_image_version: '1.9.1'
+wp_veritas_image_version: '1.10.2'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"
 wp_veritas_db_user: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -16,7 +16,7 @@ wp_veritas_cname: "{{ 'wp-veritas.epfl.ch' if server_name == 'prod' else (
 wp_veritas_deploy_name: "{{ 'wp-veritas' if server_name == 'prod' else ( 
   'wp-veritas-test' if server_name == 'test' else (
   'wp-veritas-dev')) }}"
-wp_veritas_image_version: '1.10.4'
+wp_veritas_image_version: '1.10.5'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"
 wp_veritas_db_user: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"

--- a/ansible/roles/epfl.wp-veritas/vars/main.yml
+++ b/ansible/roles/epfl.wp-veritas/vars/main.yml
@@ -16,7 +16,7 @@ wp_veritas_cname: "{{ 'wp-veritas.epfl.ch' if server_name == 'prod' else (
 wp_veritas_deploy_name: "{{ 'wp-veritas' if server_name == 'prod' else ( 
   'wp-veritas-test' if server_name == 'test' else (
   'wp-veritas-dev')) }}"
-wp_veritas_image_version: '1.10.2'
+wp_veritas_image_version: '1.10.3'
 wp_veritas_image_tag: 'epflsi/wp-veritas:{{ wp_veritas_image_version }}'
 wp_veritas_db_name: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"
 wp_veritas_db_user: "{{ 'wp-veritas-test' if server_name == 'test' else 'wp-veritas' }}"

--- a/app/client/main.js
+++ b/app/client/main.js
@@ -1,12 +1,12 @@
 import Tequila from "meteor/epfl:accounts-tequila";
-import React from 'react';
-import { Meteor } from 'meteor/meteor';
-import { render } from 'react-dom';
-import { Sites, OpenshiftEnvs, Themes } from '../imports/api/collections';
-import App from '../imports/ui/App';
- 
+import React from "react";
+import { Meteor } from "meteor/meteor";
+import { render } from "react-dom";
+import { Sites, OpenshiftEnvs, Themes } from "../imports/api/collections";
+import App from "../imports/ui/App";
+
 Meteor.startup(() => {
-  render(<App />, document.getElementById('render-target'));
+  render(<App />, document.getElementById("render-target"));
   Tequila.start();
 });
 

--- a/app/imports/api/collections.js
+++ b/app/imports/api/collections.js
@@ -160,6 +160,7 @@ export const Sites = new Mongo.Collection('sites', {
 Sites.tagged_search = function (text="", tags=[]) {
     // build the query
     let finder = {
+       isDeleted: false,
        $and : []
     };
 
@@ -211,8 +212,6 @@ Sites.tagged_search = function (text="", tags=[]) {
             ]
         });
     }
-
-    console.log(finder);
 
     return Sites.find(finder,
         {

--- a/app/imports/api/collections.js
+++ b/app/imports/api/collections.js
@@ -212,6 +212,8 @@ Sites.tagged_search = function (text="", tags=[]) {
         });
     }
 
+    console.log(finder);
+
     return Sites.find(finder,
         {
             sort: {

--- a/app/imports/api/methods/sites.js
+++ b/app/imports/api/methods/sites.js
@@ -338,7 +338,7 @@ const restoreSite = new VeritasValidatedMethod({
         user.username +
         " (#" +
         this.userId +
-        ") has just restore " +
+        ") has just restored " +
         site.url +
         " on wp-veritas! #wpSiteRestored";
       Telegram.sendMessage(message);

--- a/app/imports/api/methods/tests/sites.test.js
+++ b/app/imports/api/methods/tests/sites.test.js
@@ -76,6 +76,7 @@ if (Meteor.isServer) {
         tags: [tag1, tag2],
         professors: [],
         wpInfra: true,
+        isDeleted: false
       };
 
       insertSite._execute(context, args);
@@ -117,6 +118,7 @@ if (Meteor.isServer) {
         tags: [],
         professors: [],
         wpInfra: true,
+        isDeleted: false
       };
 
       updateSite._execute(context, args);

--- a/app/imports/api/publications.js
+++ b/app/imports/api/publications.js
@@ -11,7 +11,11 @@ import { check } from "meteor/check";
 
 if (Meteor.isServer) {
   Meteor.publish("sites.list", function () {
-    return Sites.find({}, { sort: { url: 1 } });
+    return Sites.find({ isDeleted: false }, { sort: { url: 1 } });
+  });
+
+  Meteor.publish("deleteSites.list", function () {
+    return Sites.find({ isDeleted: true }, { sort: { url: 1 } });
   });
 
   Meteor.publish("siteById", function (siteId) {

--- a/app/imports/api/schemas/sitesSchema.js
+++ b/app/imports/api/schemas/sitesSchema.js
@@ -125,6 +125,10 @@ export const sitesSchema = new SimpleSchema({
     optional: true,
     max: 50,
   },
+  isDeleted: {
+    type: Boolean,
+    defaultValue: false, 
+  },
   professors: {
     type: Array,
     label: "Professors",

--- a/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
+++ b/app/imports/api/schemas/sitesWPInfraOutsideSchema.js
@@ -30,6 +30,10 @@ export const sitesWPInfraOutsideSchema = new SimpleSchema({
       min: 2,
       custom: isRequired
   },
+  isDeleted: {
+    type: Boolean,
+    defaultValue: false, 
+  },
   openshiftEnv: {
       type: String,
       label: "Environnement openshift",

--- a/app/imports/ui/App.jsx
+++ b/app/imports/ui/App.jsx
@@ -12,6 +12,7 @@ import {
   Log,
   Professor,
   SiteProfessors,
+  Trash,
 } from "./components";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import { Loading } from "../ui/components/Messages";
@@ -53,6 +54,7 @@ class Apps extends Component {
                 <Route path="/add" component={Add} />
                 <Route path="/edit/:_id" component={Add} />
                 <Route exact path="/admin" component={Admin} />
+                <Route exact path="/trash" component={Trash} />
                 <Route path="/admin/log/list" component={Log} />
               </React.Fragment>
             ) : null}

--- a/app/imports/ui/components/admin/Trash.jsx
+++ b/app/imports/ui/components/admin/Trash.jsx
@@ -1,0 +1,122 @@
+import { withTracker } from "meteor/react-meteor-data";
+import { Meteor } from "meteor/meteor";
+import React, { Component, Fragment } from "react";
+import { Link } from "react-router-dom";
+import { Loading } from "../Messages";
+import { restoreSite } from "../../../api/methods/sites";
+import Swal from 'sweetalert2'
+
+const Cells = (props) => (
+  <tbody>
+    {props.sites.map((site, index) => (
+      <tr key={site._id}>
+        <th scope="row">{index + 1}</th>
+        <td>
+          <a href={site.url} target="_blank">
+            {site.url}
+          </a>
+        </td>
+        <td>{site.getWpInfra()}</td>
+        <td>{site.openshiftEnv}</td>
+        <td>
+          <Link className="mr-2" to={`/edit/${site._id}`}>
+            <button
+              type="button"
+              style={{ marginBottom: "3px" }}
+              className="btn btn-outline-primary"
+            >
+              Éditer
+            </button>
+          </Link>
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+              onClick={() => {
+                  props.handleClickOnRestoreButton(site._id);
+              }}
+          >
+            Restaurer
+          </button>
+        </td>
+      </tr>
+    ))}
+  </tbody>
+);
+
+class Trash extends Component {
+
+  handleClickOnRestoreButton = (siteId) => {
+
+    let site = Sites.findOne({_id: siteId});
+
+    Swal.fire({
+      title: `Voulez vous vraiment restaurer le site: ${ site.url } ?`,
+      text: 'Cette action est irréversible',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: 'Oui',
+      cancelButtonText: 'Non'
+    }).then((result) => {
+      if(result.value){
+        this.restoreSite(siteId);
+      }
+    })
+  }
+
+  restoreSite = (siteId) => {
+    restoreSite.call({ siteId }, function (error, siteId) {
+      if (error) {
+        console.log(`ERROR restoreSite ${error}`);
+      }
+    });
+  };
+
+  render() {
+    let content;
+    if (this.props.loading) {
+      return <Loading />;
+    } else {
+      content = (
+        <Fragment>
+          <h4 className="py-4 float-left">
+            Corbeille
+          </h4>
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th className="w-5" scope="col">
+                  #
+                </th>
+                <th className="w-25" scope="col">
+                  URL
+                </th>
+                <th className="w-10" scope="col">
+                  Infrastructure VPSI
+                </th>
+                <th className="w-10" scope="col">
+                  Env. Openshift
+                </th>
+                <th className="w-30">Actions</th>
+              </tr>
+            </thead>
+            <Cells
+              sites={this.props.sites}
+              handleClickOnRestoreButton={this.handleClickOnRestoreButton}
+            />
+          </table>
+        </Fragment>
+      );
+      return content;
+    }
+  }
+}
+
+export default withTracker(() => {
+  const handle = Meteor.subscribe("deleteSites.list");
+  return {
+    loading: !handle.ready(),
+    sites: Sites.find({ isDeleted: true }, { sort: { url: 1 } }).fetch(),
+  };
+})(Trash);

--- a/app/imports/ui/components/admin/Trash.jsx
+++ b/app/imports/ui/components/admin/Trash.jsx
@@ -3,7 +3,7 @@ import { Meteor } from "meteor/meteor";
 import React, { Component, Fragment } from "react";
 import { Link } from "react-router-dom";
 import { Loading } from "../Messages";
-import { restoreSite } from "../../../api/methods/sites";
+import { restoreSite, removePermanentlySite } from "../../../api/methods/sites";
 import Swal from 'sweetalert2'
 
 const Cells = (props) => (
@@ -36,6 +36,15 @@ const Cells = (props) => (
               }}
           >
             Restaurer
+          </button> &nbsp;
+          <button
+            type="button"
+            className="btn btn-outline-danger"
+              onClick={() => {
+                  props.handleClickOnRemovePermanentlyButton(site._id);
+              }}
+          >
+            Supprimer définitivement
           </button>
         </td>
       </tr>
@@ -44,6 +53,26 @@ const Cells = (props) => (
 );
 
 class Trash extends Component {
+
+  handleClickOnRemovePermanentlyButton = (siteId) => {
+
+    let site = Sites.findOne({_id: siteId});
+
+    Swal.fire({
+      title: `Voulez vous vraiment supprimer définitivement le site: ${ site.url } ?`,
+      text: 'Cette action est irréversible',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: 'Oui',
+      cancelButtonText: 'Non'
+    }).then((result) => {
+      if(result.value){
+        this.removePermanentlySite(siteId);
+      }
+    })
+  }
 
   handleClickOnRestoreButton = (siteId) => {
 
@@ -64,6 +93,14 @@ class Trash extends Component {
       }
     })
   }
+
+  removePermanentlySite = (siteId) => {
+    removePermanentlySite.call({ siteId }, function (error, siteId) {
+      if (error) {
+        console.log(`ERROR restoreSite ${error}`);
+      }
+    });
+  };
 
   restoreSite = (siteId) => {
     restoreSite.call({ siteId }, function (error, siteId) {
@@ -104,6 +141,7 @@ class Trash extends Component {
             <Cells
               sites={this.props.sites}
               handleClickOnRestoreButton={this.handleClickOnRestoreButton}
+              handleClickOnRemovePermanentlyButton={this.handleClickOnRemovePermanentlyButton}
             />
           </table>
         </Fragment>

--- a/app/imports/ui/components/admin/Trash.jsx
+++ b/app/imports/ui/components/admin/Trash.jsx
@@ -2,6 +2,7 @@ import { withTracker } from "meteor/react-meteor-data";
 import { Meteor } from "meteor/meteor";
 import React, { Component, Fragment } from "react";
 import { Link } from "react-router-dom";
+import { Sites } from "../../../api/collections";
 import { Loading } from "../Messages";
 import { restoreSite, removePermanentlySite } from "../../../api/methods/sites";
 import Swal from 'sweetalert2'

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -157,7 +157,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.10.2</div>
+                    <div className="dropdown-item">Version 1.10.3</div>
                   </div>
                 </li>
               ) : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -144,6 +144,14 @@ class Header extends Component {
                     </NavLink>
                     <NavLink
                       className="dropdown-item"
+                      exact
+                      to="/trash"
+                      activeClassName="active"
+                      >
+                        Corbeille
+                    </NavLink>
+                    <NavLink
+                      className="dropdown-item"
                       to="/admin/log/list"
                       activeClassName="active"
                     >

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -157,7 +157,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.10.3</div>
+                    <div className="dropdown-item">Version 1.10.4</div>
                   </div>
                 </li>
               ) : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -157,7 +157,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.10.5</div>
+                    <div className="dropdown-item">Version 1.10.6</div>
                   </div>
                 </li>
               ) : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -157,7 +157,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.9.1</div>
+                    <div className="dropdown-item">Version 1.10.2</div>
                   </div>
                 </li>
               ) : null}

--- a/app/imports/ui/components/header/Header.jsx
+++ b/app/imports/ui/components/header/Header.jsx
@@ -157,7 +157,7 @@ class Header extends Component {
                     >
                       Voir les logs
                     </NavLink>
-                    <div className="dropdown-item">Version 1.10.4</div>
+                    <div className="dropdown-item">Version 1.10.5</div>
                   </div>
                 </li>
               ) : null}

--- a/app/imports/ui/components/index.jsx
+++ b/app/imports/ui/components/index.jsx
@@ -3,6 +3,7 @@ export { Footer } from './footer/Footer';
 export { default as Add } from './sites/Add';
 export { default as List } from './sites/List';
 export { default as Admin } from './admin/Admin';
+export { default as Trash } from './admin/Trash';
 export { default as Search } from './sites/Search';
 export { default as Tag } from './tags/Tag';
 export { default as SiteTags } from './tags/SiteTags';

--- a/app/imports/ui/components/professors/SiteProfessors.jsx
+++ b/app/imports/ui/components/professors/SiteProfessors.jsx
@@ -131,7 +131,7 @@ export default withTracker(() => {
 
   return {
     professors: Professors.find({}, { sort: { sciper: 1 } }).fetch(),
-    sites: Sites.find({}).fetch(),
+    sites: Sites.find({ isDeleted: false }).fetch(),
   };
 })(SiteProfessors);
 

--- a/app/imports/ui/components/sites/List.jsx
+++ b/app/imports/ui/components/sites/List.jsx
@@ -254,6 +254,6 @@ export default withTracker(() => {
   const handle = Meteor.subscribe("sites.list");
   return {
     loading: !handle.ready(),
-    sites: Sites.find({}, { sort: { url: 1 } }).fetch(),
+    sites: Sites.find({ isDeleted: false }, { sort: { url: 1 } }).fetch(),
   };
 })(List);

--- a/app/imports/ui/components/sites/List.jsx
+++ b/app/imports/ui/components/sites/List.jsx
@@ -112,13 +112,14 @@ class List extends Component {
   search = (event) => {
     const keyword = event.target.value;
     const sites = Sites.find({
+      isDeleted: false,
       url: { $regex: ".*" + keyword + ".*", $options: "i" },
     }).fetch();
     this.setState({ searchValue: keyword, sites: sites });
   };
 
   export = () => {
-    let sites = Sites.find({}).fetch();
+    let sites = Sites.find({ isDeleted: false }).fetch();
 
     sites.forEach(function (site) {
       site.categories = site.categories

--- a/app/imports/ui/components/sites/Search.jsx
+++ b/app/imports/ui/components/sites/Search.jsx
@@ -1,150 +1,144 @@
-import { withTracker } from 'meteor/react-meteor-data';
-import React from 'react';
-import { Sites } from '../../../api/collections'
-import { Formik, Field, ErrorMessage } from 'formik';
-import { CustomError, CustomInput } from '../CustomFields';
-import * as yup from 'yup';
-import ReactHtmlParser from 'react-html-parser';
-import { Loading } from '../Messages';
-
+import { withTracker } from "meteor/react-meteor-data";
+import React from "react";
+import { Sites } from "../../../api/collections";
+import { Formik, Field, ErrorMessage } from "formik";
+import { CustomError, CustomInput } from "../CustomFields";
+import * as yup from "yup";
+import ReactHtmlParser from "react-html-parser";
+import { Loading } from "../Messages";
 
 class Search extends React.Component {
-
   urlSchema = yup.object().shape({
-    url: yup.
-      string('Champ doit être un string').
-      url('URL non valide').
-      min(17, 'URL la plus courte est du genre https://x.epfl.ch').
-      test('startsWithHttps', 'URL doit commencer par https://', 
-        function(value) {
-          if (value && !value.startsWith('https://')) {
-            return false;
-          }
-          return true;
+    url: yup
+      .string("Champ doit être un string")
+      .url("URL non valide")
+      .min(17, "URL la plus courte est du genre https://x.epfl.ch")
+      .test("startsWithHttps", "URL doit commencer par https://", function (value) {
+        if (value && !value.startsWith("https://")) {
+          return false;
         }
-      ).
-      required('Champ obligatoire')
-    });
+        return true;
+      })
+      .required("Champ obligatoire"),
+  });
 
-    constructor(props) {
-      super(props);
+  constructor(props) {
+    super(props);
 
-      this.state = {
-        unitName: '',
-        site: {},
-        urlSearched: '',
-      }
-    }
+    this.state = {
+      unitName: "",
+      site: {},
+      urlSearched: "",
+    };
+  }
 
-    getUnitName = (unitId) => {
-      Meteor.call('getUnitFromLDAP', unitId, (error, unitLDAPinformations) => {
-        if (error) {
-          console.log(`ERROR ${error}`);
-        } else {
-          let unitName = unitLDAPinformations.cn + " (" + unitId + ")";
-          this.setState( 
-            { unitName: unitName } 
-          );
-        }
-      });
-    }
-
-    submit = (values, actions) => {
-
-      let res = "";
-      this.props.sites.forEach(currentSite => {
-        if (values.url.startsWith(currentSite.url)) {
-          if (currentSite.url.length > res.length) {
-              
-            // Example: 
-            // Existing WordPress instance :
-            // - https://www.epfl.ch/campus/services/ressources
-            // - https://www.epfl.ch/campus/services
-            // User URL: https://www.epfl.ch/campus/services/ressources-informatiques/support-informatique/linux
-            // Expected result: https://www.epfl.ch/campus/services/wp-admin
-            // And not https://www.epfl.ch/campus/services/ressources/wp-admin
-
-            let check = currentSite.url + "/";
-            if (values.url.startsWith(check) || values.url == currentSite.url) {
-              res = currentSite.url; 
-              this.getUnitName(currentSite.unitId);
-              this.setState({ site: currentSite , urlSearched: values.url });
-            }                    
-          }
-        }
-      });
-      if (res == "") {
-        this.setState({ site: {} , urlSearched: values.url });
-      }
-      actions.setSubmitting(false);
-      actions.resetForm();
-    }
-
-    loading = () => {
-      return this.props.sites === undefined;
-    }
-
-    render() {  
-      let content;
-
-      if (this.loading()) {
-        content = <Loading />
+  getUnitName = (unitId) => {
+    Meteor.call("getUnitFromLDAP", unitId, (error, unitLDAPinformations) => {
+      if (error) {
+        console.log(`ERROR ${error}`);
       } else {
+        let unitName = unitLDAPinformations.cn + " (" + unitId + ")";
+        this.setState({ unitName: unitName });
+      }
+    });
+  };
 
-        let res = "";
-        if (this.state.site == {}) {
-          res = `Le site <a href='${ this.state.urlSearched }' target="_blank">${ this.state.urlSearched }</a> n'est pas un site de l'infrastructure WordPress géré par la VPSI`;
-        } else {
-          if (this.state.site.wpInfra) {
-            res = this.state.site.url + '/wp-admin';
-            res = `L'instance WordPress est : <a href='${ res }' target="_blank">${ res }</a>`;
-            res += ` <br />Unité de rattachement <strong>${ this.state.unitName }</strong>`;
-          } else {
-            res = `Le site <a href='${ this.state.urlSearched }' target="_blank">${ this.state.urlSearched }</a> n'est pas un site de l'infrastructure WordPress géré par la VPSI`;
+  submit = (values, actions) => {
+    let res = "";
+    this.props.sites.forEach((currentSite) => {
+      if (values.url.startsWith(currentSite.url)) {
+        if (currentSite.url.length > res.length) {
+          // Example:
+          // Existing WordPress instance :
+          // - https://www.epfl.ch/campus/services/ressources
+          // - https://www.epfl.ch/campus/services
+          // User URL: https://www.epfl.ch/campus/services/ressources-informatiques/support-informatique/linux
+          // Expected result: https://www.epfl.ch/campus/services/wp-admin
+          // And not https://www.epfl.ch/campus/services/ressources/wp-admin
+
+          let check = currentSite.url + "/";
+          if (values.url.startsWith(check) || values.url == currentSite.url) {
+            res = currentSite.url;
+            this.getUnitName(currentSite.unitId);
+            this.setState({ site: currentSite, urlSearched: values.url });
           }
         }
-
-        let displayResult;
-        if (this.state.urlSearched !== '') {
-          displayResult = ( <h4 className="py-4">{ ReactHtmlParser(res) }</h4> )
-        }
-
-        content = (
-          <div className="">
-            <h4 className="py-4">Quelle est l'instance WordPress de cette URL ?</h4>
-            <Formik
-              onSubmit={ this.submit }
-              initialValues={ {url: ''} }
-              validationSchema={this.urlSchema}
-              validateOnBlur={ false }
-              validateOnChange={ false }
-            >
-            { ({
-                handleSubmit,
-                isSubmitting,
-                values,
-              }) => (              
-                <form method="GET" onSubmit={ handleSubmit } className="bg-white border p-4">   
-                  <Field placeholder="URL du site" label="URL" name="url" type="text" component={ CustomInput } />
-                  <ErrorMessage name="url" component={ CustomError } />
-                  <div className="my-1 text-right">
-                      <button type="submit" disabled={ isSubmitting } className="btn btn-primary">Rechercher</button>
-                  </div>
-                </form>
-            )}
-            </Formik>
-
-            { displayResult }
-          </div>
-        )
       }
-      return content;
+    });
+    if (res == "") {
+      this.setState({ site: {}, urlSearched: values.url });
     }
+    actions.setSubmitting(false);
+  };
+
+  loading = () => {
+    return this.props.sites === undefined;
+  };
+
+  render() {
+    let content;
+
+    if (this.loading()) {
+      content = <Loading />;
+    } else {
+      let res = "";
+      if (this.state.site == {}) {
+        res = `Le site <a href='${this.state.urlSearched}' target="_blank">${this.state.urlSearched}</a> n'est pas un site de l'infrastructure WordPress géré par la VPSI`;
+      } else {
+        if (this.state.site.wpInfra) {
+          res = this.state.site.url + "/wp-admin";
+          res = `L'instance WordPress est : <a href='${res}' target="_blank">${res}</a>`;
+          res += ` <br />Unité de rattachement <strong>${this.state.unitName}</strong>`;
+        } else {
+          res = `Le site <a href='${this.state.urlSearched}' target="_blank">${this.state.urlSearched}</a> n'est pas un site de l'infrastructure WordPress géré par la VPSI`;
+        }
+      }
+
+      let displayResult;
+      if (this.state.urlSearched !== "") {
+        displayResult = <h4 className="py-4">{ReactHtmlParser(res)}</h4>;
+      }
+
+      content = (
+        <div className="">
+          <h4 className="py-4">Quelle est l'instance WordPress de cette URL ?</h4>
+          <Formik
+            onSubmit={this.submit}
+            initialValues={{ url: "" }}
+            validationSchema={this.urlSchema}
+            validateOnBlur={false}
+            validateOnChange={false}
+          >
+            {({ handleSubmit, isSubmitting, values }) => (
+              <form method="GET" onSubmit={handleSubmit} className="bg-white border p-4">
+                <Field
+                  placeholder="URL du site"
+                  label="URL"
+                  name="url"
+                  type="text"
+                  component={CustomInput}
+                />
+                <ErrorMessage name="url" component={CustomError} />
+                <div className="my-1 text-right">
+                  <button type="submit" disabled={isSubmitting} className="btn btn-primary">
+                    Rechercher
+                  </button>
+                </div>
+              </form>
+            )}
+          </Formik>
+
+          {displayResult}
+        </div>
+      );
+    }
+    return content;
+  }
 }
 
 export default withTracker(() => {
-  Meteor.subscribe('sites.list');
+  Meteor.subscribe("sites.list");
   return {
-    sites: Sites.find({ siteDeleted: false }, {sort: {url: 1}}).fetch(),
+    sites: Sites.find({ isDeleted: false }, { sort: { url: 1 } }).fetch(),
   };
 })(Search);

--- a/app/imports/ui/components/sites/Search.jsx
+++ b/app/imports/ui/components/sites/Search.jsx
@@ -145,6 +145,6 @@ class Search extends React.Component {
 export default withTracker(() => {
   Meteor.subscribe('sites.list');
   return {
-    sites: Sites.find({}, {sort: {url: 1}}).fetch(),
+    sites: Sites.find({ siteDeleted: false }, {sort: {url: 1}}).fetch(),
   };
 })(Search);

--- a/app/imports/ui/components/tags/SiteTags.jsx
+++ b/app/imports/ui/components/tags/SiteTags.jsx
@@ -189,7 +189,7 @@ export default withTracker(() => {
     facultyTags: facultyTags,
     instituteTags: instituteTags,
     fieldOfResearchTags: fieldOfResearchTags,
-    sites: Sites.find({}).fetch(),
+    sites: Sites.find({ isDeleted: false }).fetch(),
   };
 })(SiteTags);
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.9.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "https://wp-veritas.epfl.ch",
   "bugs": {
     "url": "https://github.com/epfl-si/wp-veritas/issues"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "https://wp-veritas.epfl.ch",
   "bugs": {
     "url": "https://github.com/epfl-si/wp-veritas/issues"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "https://wp-veritas.epfl.ch",
   "bugs": {
     "url": "https://github.com/epfl-si/wp-veritas/issues"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "https://wp-veritas.epfl.ch",
   "bugs": {
     "url": "https://github.com/epfl-si/wp-veritas/issues"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-veritas",
-  "version": "1.9.1",
+  "version": "1.10.2",
   "description": "https://wp-veritas.epfl.ch",
   "bugs": {
     "url": "https://github.com/epfl-si/wp-veritas/issues"

--- a/app/server/api/categories.js
+++ b/app/server/api/categories.js
@@ -139,6 +139,7 @@ Api.addRoute(
       }
       return formatSiteCategories(
         Sites.find({
+          isDeleted: false,
           categories: { $elemMatch: { name: categoryName } },
         }).fetch()
       );

--- a/app/server/api/professors.js
+++ b/app/server/api/professors.js
@@ -73,7 +73,7 @@ Api.addRoute(
     //        Error management
     get: function () {
       let sciper = this.urlParams.sciper;
-      let sites = Sites.find({ "professors.sciper": sciper }).fetch();
+      let sites = Sites.find({ isDeleted: false, "professors.sciper": sciper }).fetch();
       let tags = [];
       sites.forEach((site) => {
         if (site.tags.length > 0) {

--- a/app/server/api/sites.js
+++ b/app/server/api/sites.js
@@ -79,10 +79,11 @@ Api.addRoute(
         if (siteUrl.endsWith("/")) {
           siteUrl = siteUrl.slice(0, -1);
         }
-        return formatSiteCategories(Sites.find({ url: siteUrl }).fetch());
+        return formatSiteCategories(Sites.find({ isDeleted: false, url: siteUrl }).fetch());
       } else if (query && this.queryParams.search_url) {
         return formatSiteCategories(
           Sites.find({
+            isDeleted: false,
             url: { $regex: this.queryParams.search_url, $options: "-i" },
           }).fetch()
         );
@@ -100,7 +101,7 @@ Api.addRoute(
         return formatSiteCategories(sites);
       } else {
         // nope, we are here for all the sites data
-        let sites = Sites.find({}).fetch();
+        let sites = Sites.find({ isDeleted: false }).fetch();
         return formatSiteCategories(sites);
       }
     },

--- a/app/server/api/sites.js
+++ b/app/server/api/sites.js
@@ -67,6 +67,7 @@ import getUnits from "../units";
 // and to: /api/v1/sites?text=... to search a list of sites from a text
 // and to: /api/v1/sites?tags=... to search a list of sites from an array of tags with status "created" or "no-wordpress"
 // and to: /api/v1/sites?tagged=true to retrieve the list of sites with at least a tag with status "created" or "no-wordpress"
+// and to  /api/v1/sites?with_deleted_sites=true
 Api.addRoute(
   "sites",
   { authRequired: false },
@@ -99,9 +100,12 @@ Api.addRoute(
       } else if (query && this.queryParams.tagged) {
         let sites = Sites.tagged_search();
         return formatSiteCategories(sites);
+      } else if (query && this.queryParams.with_deleted_sites) {
+        let sites = Sites.find({}).fetch();
+        return formatSiteCategories(sites);
       } else {
         // nope, we are here for all the sites data
-        let sites = Sites.find({}).fetch();
+        let sites = Sites.find({ isDeleted: false}).fetch();
         return formatSiteCategories(sites);
       }
     },

--- a/app/server/api/sites.js
+++ b/app/server/api/sites.js
@@ -101,7 +101,7 @@ Api.addRoute(
         return formatSiteCategories(sites);
       } else {
         // nope, we are here for all the sites data
-        let sites = Sites.find({ isDeleted: false }).fetch();
+        let sites = Sites.find({}).fetch();
         return formatSiteCategories(sites);
       }
     },

--- a/app/server/api/sites.js
+++ b/app/server/api/sites.js
@@ -3,7 +3,7 @@ import { Api, formatSiteCategories } from "./utils";
 import getUnits from "../units";
 
 /**
- * @api {get} /sites  Get all sites
+ * @api {get} /sites  Get all active sites (isDeleted: false)
  * @apiGroup Sites
  *
  * @apiSuccessExample Success-Response:
@@ -108,6 +108,50 @@ Api.addRoute(
   }
 );
 
+/**
+ * @api {get} /inventory/entries  Get all sites (active or deleted)
+ * @apiGroup Sites
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 200 OK
+ *     [
+ *       ...,
+ *       {
+ *         "_id": "f7CaxxouACbWiYjQY",
+ *         "url": "https://www.epfl.ch/campus/services/canari",
+ *         "slug": "",
+ *         "tagline": "Canari",
+ *         "title": "Test",
+ *         "openshiftEnv": "www",
+ *         "category": "GeneralPublic",
+ *         "theme": "wp-theme-2018",
+ *         "languages": [
+ *           "en",
+ *           "fr"
+ *         ],
+ *         "unitId": "13031",
+ *         "unitName": "idev-ing",
+ *         "unitNameLevel2": "si",
+ *         "snowNumber": "",
+ *         "comment": "Site canari pour tester l'image",
+ *         "createdDate": "2020-03-05T09:52:06.310Z",
+ *         "userExperience": false,
+ *         "tags": [],
+ *         "professors": [],
+ *         "wpInfra": true,
+ *         "userExperienceUniqueLabel": ""
+ *       },
+ *       ...,
+ *     ]
+ * @apiError SitesNotFound  No sites returned
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "message": "SitesNotFound"
+ *     }
+ *
+ */
 Api.addRoute(
   "inventory/entries",
   { authRequired: false },

--- a/app/server/api/sites.js
+++ b/app/server/api/sites.js
@@ -262,7 +262,7 @@ Api.addRoute(
         let units = getUnits(this.urlParams.sciper);
   
         // Get all sites whose unit is present in 'units'
-        let sites = Sites.find({ unitId: { $in: units } }).fetch();
+        let sites = Sites.find({ isDeleted: false, unitId: { $in: units } }).fetch();
   
         // Create an array with only wp-admin URL
         admins = [];
@@ -327,6 +327,7 @@ Api.addRoute(
       let tag1 = this.urlParams.tag1.toUpperCase();
       let tag2 = this.urlParams.tag2.toUpperCase();
       let sites = Sites.find({
+        isDeleted: false,
         "tags.name_en": tag1,
         "tags.name_en": tag2,
       }).fetch();
@@ -387,6 +388,7 @@ Api.addRoute(
       let tag1 = this.urlParams.tag1.toUpperCase();
       let tag2 = this.urlParams.tag2.toUpperCase();
       let sites = Sites.find({
+        isDeleted: false,
         "tags.name_fr": tag1,
         "tags.name_fr": tag2,
       }).fetch();

--- a/app/server/api/tags.js
+++ b/app/server/api/tags.js
@@ -80,7 +80,7 @@ Api.addRoute(
         let tagId = this.urlParams.id;
   
         // Récupère tous les sites qui ont le tag STI
-        let sites = Sites.find({ "tags._id": tagId }).fetch();
+        let sites = Sites.find({ isDeleted: false, "tags._id": tagId }).fetch();
   
         let tags = [];
         let scipers = [];

--- a/app/server/api/tests/api-sites.test.js
+++ b/app/server/api/tests/api-sites.test.js
@@ -30,6 +30,7 @@ getExpectedSiteResult = () => {
       tags: site.tags,
       professors: site.professors,
       wpInfra: true,
+      isDeleted: false
     },
   ];
   return expectedResult;

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -256,6 +256,24 @@ updateSitesDeleteCategory = () => {
   console.log("All sites are updated");
 }
 
+updateSitesWithoutIsDeletedField = () => {
+  let sites = Sites.find().fetch();
+  console.log("Nb sites: ", sites.length);
+  let nb = 1;
+  sites.forEach((site) => {
+    if (!("isDeleted" in site)) {
+      console.log("Site: ", site.url);
+      let siteDocument = {
+        isDeleted: false
+      };
+      Sites.update({ _id: site._id }, { $set: siteDocument });
+      nb += 1;
+    }
+  });
+  console.log("Nb sites without 'isDeleted' Field: ", nb);
+  console.log("All sites are updated");
+}
+
 importData = () => {
   /*
   const absoluteUrl = Meteor.absoluteUrl();
@@ -269,7 +287,9 @@ importData = () => {
   //updateCategoriesFromCategory();
   //updateSitesWithoutProfessors();
 
-  updateSitesDeleteCategory();
+  //updateSitesDeleteCategory();
+
+  updateSitesWithoutIsDeletedField();
 };
 
 export { importData };

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -18,7 +18,7 @@ import "./indexes";
 
 import { getEnvironment } from "../imports/api/utils";
 
-let importDatas = false;
+let importDatas = true;
 // Warning: Tequila is needed to create the DB entries the first time that
 // you run the app — afterwards you can disable it to have more dev comfort.
 let forceTequila = false;


### PR DESCRIPTION
Cette PR a pour but de gérer la suppresion d'un site WordPress dans wp-veritas par la définition d'un nouveau champ 'isDeleted' au lieu de la suppresion du 'document' (au sens mongodb) site.

Todos:
[x] Ajout de ce champ 'isDeleted'
[x] Utilisation de ce champ à la création et l'édition d'un site
[x] Utilisation de ce champ dans la liste des sites de la pages d'accueil
[x] Utilisation de ce champ dans l'API REST
[x] Utilisation de ce champ dans l'export CSV
[x] Mise en place d'une corbeille permettant de restaurer un site supprimé ou de le supprimer définitivement
[x] Amélioration du message de validation car un site que l'on tente de créer peut avoir la même URL qu'un de ceux présents dans la corbeille 
