### PR TITLE
Feature/update load test data

### DIFF
--- a/app/private/inventory-test.json
+++ b/app/private/inventory-test.json
@@ -1,9960 +1,4617 @@
 {
   "_meta": {
       "hostvars": {
-          "charte_wp__www_epfl_ch": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "ScienceQA",
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": []
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "www",
-              "wp_hostname": "charte-wp.epfl.ch",
-              "wp_path": "www.epfl.ch"
-          },
-          "env_gc_os_exopge__bios": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/bios/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/bios/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/bios/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/bios/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "bios"
-          },
-          "env_gc_os_exopge__c3mp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "c3mp",
-                      "plugin:epfl_accred:unit_id": "12491",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "c3mp"
-          },
-          "env_gc_os_exopge__cag": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/cag/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/cag/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/cag/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/cag/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "cag"
-          },
-          "env_gc_os_exopge__cns": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "ip",
-                      "plugin:epfl_accred:unit_id": "13383",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "cns"
-          },
-          "env_gc_os_exopge__dcgprogram": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/dcgprogram/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/dcgprogram/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/dcgprogram/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/dcgprogram/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "dcgprogram"
-          },
-          "env_gc_os_exopge__decouvrir_le_numerique": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "ph-ic",
-                      "plugin:epfl_accred:unit_id": "11900",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "decouvrir-le-numerique"
-          },
-          "env_gc_os_exopge__dynnet": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "ph-ic",
-                      "plugin:epfl_accred:unit_id": "11900",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "dynnet"
-          },
-          "env_gc_os_exopge__ekv": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ekv/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ekv/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ekv/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ekv/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "ekv"
-          },
-          "env_gc_os_exopge__entrepreneurship": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/entrepreneurship/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/entrepreneurship/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/entrepreneurship/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/entrepreneurship/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "entrepreneurship"
-          },
-          "env_gc_os_exopge__euclid": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/euclid/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/euclid/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/euclid/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/euclid/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "euclid"
-          },
-          "env_gc_os_exopge__gfo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "sci-sti-lt",
-                      "plugin:epfl_accred:unit_id": "12146",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "gfo"
-          },
-          "env_gc_os_exopge__ggsd": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ggsd/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ggsd/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ggsd/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/ggsd/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "ggsd"
-          },
-          "env_gc_os_exopge__gonczy_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "upgon",
-                      "plugin:epfl_accred:unit_id": "11155",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "gonczy-lab"
-          },
-          "env_gc_os_exopge__gr_ost": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "gr-ost"
-          },
-          "env_gc_os_exopge__hsca": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lem",
-                      "plugin:epfl_accred:unit_id": "10486",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "hsca"
-          },
-          "env_gc_os_exopge__icss12": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "cclab",
-                      "plugin:epfl_accred:unit_id": "10234",
-                      "stylesheet": "epfl-blank"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "icss12"
-          },
-          "env_gc_os_exopge__innoseed_enac": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "enac-inno",
-                      "plugin:epfl_accred:unit_id": "13324",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "innoseed-enac"
-          },
-          "env_gc_os_exopge__labos": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/labos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/labos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/labos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/labos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "labos"
-          },
-          "env_gc_os_exopge__lcvmm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lcvmm",
-                      "plugin:epfl_accred:unit_id": "10163",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "lcvmm"
-          },
-          "env_gc_os_exopge__ldia2019": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lai",
-                      "plugin:epfl_accred:unit_id": "10351",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "ldia2019"
-          },
-          "env_gc_os_exopge__lmaf": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lmaf",
-                      "plugin:epfl_accred:unit_id": "10367",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "lmaf"
-          },
-          "env_gc_os_exopge__lpmn": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/lpmn/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/lpmn/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/lpmn/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/lpmn/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "lpmn"
-          },
-          "env_gc_os_exopge__lprx": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lprx",
-                      "plugin:epfl_accred:unit_id": "10144",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "lprx"
-          },
-          "env_gc_os_exopge__mechanical_spectroscopy": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lpmc",
-                      "plugin:epfl_accred:unit_id": "10142",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "mechanical-spectroscopy"
-          },
-          "env_gc_os_exopge__microbs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "microbs",
-                      "plugin:epfl_accred:unit_id": "13117",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "microbs"
-          },
-          "env_gc_os_exopge__mlo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "mlo",
-                      "plugin:epfl_accred:unit_id": "13319",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "mlo"
-          },
-          "env_gc_os_exopge__nal": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nal/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nal/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nal/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nal/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "nal"
-          },
-          "env_gc_os_exopge__naveiras_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/naveiras-lab/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/naveiras-lab/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/naveiras-lab/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/naveiras-lab/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "naveiras-lab"
-          },
-          "env_gc_os_exopge__nextgen": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lasig",
-                      "plugin:epfl_accred:unit_id": "10244",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "nextgen"
-          },
-          "env_gc_os_exopge__nm2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  require(/srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nm2/wp-settings.php): failed to open stream: No such file or directory in phar:///usr/local/bin/wp/php/WP_CLI/Runner.php on line 1182\\n', b\"PHP Fatal error:  require(): Failed opening required '/srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nm2/wp-settings.php' (include_path='phar:///usr/local/bin/wp/vendor/phpunit/php-token-stream:phar:///usr/local/bin/wp/vendor/phpunit/phpunit-mock-objects:phar:///usr/local/bin/wp/vendor/phpunit/php-code-coverage:phar:///usr/local/bin/wp/vendor/phpunit/phpunit:phar:///usr/local/bin/wp/vendor/symfony/yaml:.:/usr/share/php') in phar:///usr/local/bin/wp/php/WP_CLI/Runner.php on line 1182\\n\"]",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  require(/srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nm2/wp-settings.php): failed to open stream: No such file or directory in phar:///usr/local/bin/wp/php/WP_CLI/Runner.php on line 1182\\n', b\"PHP Fatal error:  require(): Failed opening required '/srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/nm2/wp-settings.php' (include_path='phar:///usr/local/bin/wp/vendor/phpunit/php-token-stream:phar:///usr/local/bin/wp/vendor/phpunit/phpunit-mock-objects:phar:///usr/local/bin/wp/vendor/phpunit/php-code-coverage:phar:///usr/local/bin/wp/vendor/phpunit/phpunit:phar:///usr/local/bin/wp/vendor/symfony/yaml:.:/usr/share/php') in phar:///usr/local/bin/wp/php/WP_CLI/Runner.php on line 1182\\n\"]"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "nm2"
-          },
-          "env_gc_os_exopge__nnbe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "tne",
-                      "plugin:epfl_accred:unit_id": "12522",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "nnbe"
-          },
-          "env_gc_os_exopge__nrg2018": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "isic-ge",
-                      "plugin:epfl_accred:unit_id": "10096",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "nrg2018"
-          },
-          "env_gc_os_exopge__ntti2017": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "ntti2017"
-          },
-          "env_gc_os_exopge__pde": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "pde"
-          },
-          "env_gc_os_exopge__polylex": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "polylex"
-          },
-          "env_gc_os_exopge__pvlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "pv-lab",
-                      "plugin:epfl_accred:unit_id": "11963",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "pvlab"
-          },
-          "env_gc_os_exopge__qed": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qed/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qed/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qed/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qed/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "qed"
-          },
-          "env_gc_os_exopge__qtca2018": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qtca2018/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qtca2018/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qtca2018/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/qtca2018/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "qtca2018"
-          },
-          "env_gc_os_exopge__r4l": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/r4l/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/r4l/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/r4l/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/r4l/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "r4l"
-          },
-          "env_gc_os_exopge__rdsg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "rdsg"
-          },
-          "env_gc_os_exopge__react": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "sci-sti-dg",
-                      "plugin:epfl_accred:unit_id": "12390",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "react"
-          },
-          "env_gc_os_exopge__repro": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "dii-i",
-                      "plugin:epfl_accred:unit_id": "10710",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "repro"
-          },
-          "env_gc_os_exopge__sb": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "sb-it",
-                      "plugin:epfl_accred:unit_id": "10084",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "sb"
-          },
-          "env_gc_os_exopge__sfbe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "sfbe"
-          },
-          "env_gc_os_exopge__skyrmions": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lmgn",
-                      "plugin:epfl_accred:unit_id": "13021",
-                      "stylesheet": "epfl-blank"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "skyrmions"
-          },
-          "env_gc_os_exopge__systems": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "nal",
-                      "plugin:epfl_accred:unit_id": "12550",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "systems"
-          },
-          "env_gc_os_exopge__theos": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/theos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/theos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/theos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/gcharmier/env-gc-os-exopge.epfl.ch/htdocs/theos/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "theos"
-          },
-          "env_gc_os_exopge__yac": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "env-gc-os-exopge.epfl.ch",
-              "wp_path": "yac"
-          },
-          "env_lc_os_exopge__cdhshs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "CDHSHS",
-                      "plugin:epfl_accred:unit": "TODO obtain from wp-veritas",
-                      "plugin:epfl_accred:unit_id": "1234",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "lchaboudez",
-              "wp_hostname": "env-lc-os-exopge.epfl.ch",
-              "wp_path": "cdhshs"
-          },
-          "env_lc_os_exopge__gutenberg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "idev-ing",
-                      "plugin:epfl_accred:unit_id": "13031",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "lchaboudez",
-              "wp_hostname": "env-lc-os-exopge.epfl.ch",
-              "wp_path": "gutenberg"
-          },
-          "migration__dcsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "DCSL",
-                      "plugin:epfl_accred:unit_id": "12634",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "migration.epfl.ch",
-              "wp_path": "dcsl"
-          },
-          "migration_wp__cag": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "cag",
-                      "plugin:epfl_accred:unit_id": "13290",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "cag"
-          },
-          "migration_wp__chaire_gaz_naturel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "lms",
-                      "plugin:epfl_accred:unit_id": "10264",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "chaire-gaz-naturel"
-          },
-          "migration_wp__emploi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "rh-g",
-                      "plugin:epfl_accred:unit_id": "10776",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "emploi"
-          },
-          "migration_wp__emploi1": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "rh-g",
-                      "plugin:epfl_accred:unit_id": "10776",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "emploi"
-          },
-          "migration_wp__labs__ablasserlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upablasser",
-                      "plugin:epfl_accred:unit_id": "12938",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ablasserlab"
-          },
-          "migration_wp__labs__acces": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "acces",
-                      "plugin:epfl_accred:unit_id": "12385",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/acces"
-          },
-          "migration_wp__labs__acht": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "acht",
-                      "plugin:epfl_accred:unit_id": "13105",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/acht"
-          },
-          "migration_wp__labs__acm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-acm",
-                      "plugin:epfl_accred:unit_id": "10243",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/acm"
-          },
-          "migration_wp__labs__alice": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "alice",
-                      "plugin:epfl_accred:unit_id": "11533",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/alice"
-          },
-          "migration_wp__labs__alinek": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "idev-ing",
-                      "plugin:epfl_accred:unit_id": "13031",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/alinek"
-          },
-          "migration_wp__labs__amcv": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "amcv",
-                      "plugin:epfl_accred:unit_id": "13587",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/amcv"
-          },
-          "migration_wp__labs__anchp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "anchp",
-                      "plugin:epfl_accred:unit_id": "12478",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/anchp"
-          },
-          "migration_wp__labs__anmath": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "math-ge",
-                      "plugin:epfl_accred:unit_id": "13393",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/anmath"
-          },
-          "migration_wp__labs__anmc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "anmc",
-                      "plugin:epfl_accred:unit_id": "11991",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/anmc"
-          },
-          "migration_wp__labs__apc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "spc-ge",
-                      "plugin:epfl_accred:unit_id": "12266",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/apc"
-          },
-          "migration_wp__labs__aphys": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "aphys",
-                      "plugin:epfl_accred:unit_id": "12616",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/aphys"
-          },
-          "migration_wp__labs__aprl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "aprl",
-                      "plugin:epfl_accred:unit_id": "12574",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/aprl"
-          },
-          "migration_wp__labs__aqua": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "aqua",
-                      "plugin:epfl_accred:unit_id": "12178",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/aqua"
-          },
-          "migration_wp__labs__archizoom": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "archizoom",
-                      "plugin:epfl_accred:unit_id": "10565",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/archizoom"
-          },
-          "migration_wp__labs__aspg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-jmv",
-                      "plugin:epfl_accred:unit_id": "12150",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/aspg"
-          },
-          "migration_wp__labs__auwerx_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lisp",
-                      "plugin:epfl_accred:unit_id": "11905",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/auwerx-lab"
-          },
-          "migration_wp__labs__barth_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "idev-am",
-                      "plugin:epfl_accred:unit_id": "13029",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/barth-lab"
-          },
-          "migration_wp__labs__biorob": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "biorob",
-                      "plugin:epfl_accred:unit_id": "12165",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/biorob"
-          },
-          "migration_wp__labs__bios": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "bios",
-                      "plugin:epfl_accred:unit_id": "12650",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/bios"
-          },
-          "migration_wp__labs__blokesch_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upblo",
-                      "plugin:epfl_accred:unit_id": "12076",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/blokesch-lab"
-          },
-          "migration_wp__labs__bpe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-gn",
-                      "plugin:epfl_accred:unit_id": "12053",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/bpe"
-          },
-          "migration_wp__labs__brisken_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upbri",
-                      "plugin:epfl_accred:unit_id": "11257",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/brisken-lab"
-          },
-          "migration_wp__labs__bucher_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-bucher",
-                      "plugin:epfl_accred:unit_id": "11780",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/bucher-lab"
-          },
-          "migration_wp__labs__building2050": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "build-o",
-                      "plugin:epfl_accred:unit_id": "13455",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/building2050"
-          },
-          "migration_wp__labs__c3mp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "c3mp",
-                      "plugin:epfl_accred:unit_id": "12491",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/c3mp"
-          },
-          "migration_wp__labs__cag": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cag",
-                      "plugin:epfl_accred:unit_id": "13290",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cag"
-          },
-          "migration_wp__labs__cama": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cama",
-                      "plugin:epfl_accred:unit_id": "12764",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cama"
-          },
-          "migration_wp__labs__cclab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cclab",
-                      "plugin:epfl_accred:unit_id": "10234",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cclab"
-          },
-          "migration_wp__labs__cdh_test": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cdh-di",
-                      "plugin:epfl_accred:unit_id": "10475",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cdh-test"
-          },
-          "migration_wp__labs__cdt": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ssie-ens",
-                      "plugin:epfl_accred:unit_id": "11016",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cdt"
-          },
-          "migration_wp__labs__ceat": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ceat",
-                      "plugin:epfl_accred:unit_id": "10250",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ceat"
-          },
-          "migration_wp__labs__cemi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "mtei-ge",
-                      "plugin:epfl_accred:unit_id": "11083",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cemi"
-          },
-          "migration_wp__labs__cen": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cen-ge",
-                      "plugin:epfl_accred:unit_id": "11809",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cen"
-          },
-          "migration_wp__labs__cgd": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "igm-ge",
-                      "plugin:epfl_accred:unit_id": "10307",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cgd"
-          },
-          "migration_wp__labs__chaire_gaz_naturel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lms",
-                      "plugin:epfl_accred:unit_id": "10264",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/chaire-gaz-naturel"
-          },
-          "migration_wp__labs__chili": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "chili",
-                      "plugin:epfl_accred:unit_id": "12753",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: []"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/chili"
-          },
-          "migration_wp__labs__clse": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "clse",
-                      "plugin:epfl_accred:unit_id": "12017",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/clse"
-          },
-          "migration_wp__labs__cnpa": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cnpa",
-                      "plugin:epfl_accred:unit_id": "12781",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cnpa"
-          },
-          "migration_wp__labs__cole_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upcol",
-                      "plugin:epfl_accred:unit_id": "11742",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cole-lab"
-          },
-          "migration_wp__labs__concours_alkindi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ic-do",
-                      "plugin:epfl_accred:unit_id": "10389",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/concours-alkindi"
-          },
-          "migration_wp__labs__constam_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upcda",
-                      "plugin:epfl_accred:unit_id": "11161",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/constam-lab"
-          },
-          "migration_wp__labs__cosmo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cosmo",
-                      "plugin:epfl_accred:unit_id": "12743",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cosmo"
-          },
-          "migration_wp__labs__courtine_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upcourtine",
-                      "plugin:epfl_accred:unit_id": "12556",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/courtine-lab"
-          },
-          "migration_wp__labs__cryos": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cryos",
-                      "plugin:epfl_accred:unit_id": "12533",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cryos"
-          },
-          "migration_wp__labs__csqi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "csqi",
-                      "plugin:epfl_accred:unit_id": "12495",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/csqi"
-          },
-          "migration_wp__labs__cvlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cvlab",
-                      "plugin:epfl_accred:unit_id": "10659",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/cvlab"
-          },
-          "migration_wp__labs__data": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "data",
-                      "plugin:epfl_accred:unit_id": "12327",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/data"
-          },
-          "migration_wp__labs__datathink": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "alice",
-                      "plugin:epfl_accred:unit_id": "11533",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/datathink"
-          },
-          "migration_wp__labs__dcg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "dcg",
-                      "plugin:epfl_accred:unit_id": "11887",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dcg"
-          },
-          "migration_wp__labs__dcml": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "dcml",
-                      "plugin:epfl_accred:unit_id": "13398",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dcml"
-          },
-          "migration_wp__labs__dcsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "idev-ing",
-                      "plugin:epfl_accred:unit_id": "13031",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dcsl"
-          },
-          "migration_wp__labs__dedis": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "dedis",
-                      "plugin:epfl_accred:unit_id": "13061",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dedis"
-          },
-          "migration_wp__labs__desl_pwrs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "desl",
-                      "plugin:epfl_accred:unit_id": "12494",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/desl-pwrs"
-          },
-          "migration_wp__labs__dhlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "dhlab",
-                      "plugin:epfl_accred:unit_id": "12632",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dhlab"
-          },
-          "migration_wp__labs__dias": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "dias",
-                      "plugin:epfl_accred:unit_id": "11836",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dias"
-          },
-          "migration_wp__labs__digitalfutures": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "hrc-ge",
-                      "plugin:epfl_accred:unit_id": "13327",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/digitalfutures"
-          },
-          "migration_wp__labs__disal": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "disal",
-                      "plugin:epfl_accred:unit_id": "11904",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/disal"
-          },
-          "migration_wp__labs__disopt": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "disopt",
-                      "plugin:epfl_accred:unit_id": "11879",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/disopt"
-          },
-          "migration_wp__labs__duboule_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "updub",
-                      "plugin:epfl_accred:unit_id": "11705",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/duboule-lab"
-          },
-          "migration_wp__labs__dynnet": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ph-ic",
-                      "plugin:epfl_accred:unit_id": "11900",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/dynnet"
-          },
-          "migration_wp__labs__east": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "east-co",
-                      "plugin:epfl_accred:unit_id": "12813",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/east"
-          },
-          "migration_wp__labs__echo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "echo",
-                      "plugin:epfl_accred:unit_id": "10273",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/echo"
-          },
-          "migration_wp__labs__ecol": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ecol",
-                      "plugin:epfl_accred:unit_id": "11221",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ecol"
-          },
-          "migration_wp__labs__ecotox": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "enac-do",
-                      "plugin:epfl_accred:unit_id": "10203",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ecotox"
-          },
-          "migration_wp__labs__ecps": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ecps",
-                      "plugin:epfl_accred:unit_id": "12653",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ecps"
-          },
-          "migration_wp__labs__edlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-sci-iel",
-                      "plugin:epfl_accred:unit_id": "12664",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/edlab"
-          },
-          "migration_wp__labs__eelab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "smx-ens",
-                      "plugin:epfl_accred:unit_id": "11011",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/eelab"
-          },
-          "migration_wp__labs__eesd": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "eesd",
-                      "plugin:epfl_accred:unit_id": "12170",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "de",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/eesd"
-          },
-          "migration_wp__labs__elab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-ka",
-                      "plugin:epfl_accred:unit_id": "11978",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/elab"
-          },
-          "migration_wp__labs__emc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-fr",
-                      "plugin:epfl_accred:unit_id": "12147",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/emc"
-          },
-          "migration_wp__labs__eml": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "eml",
-                      "plugin:epfl_accred:unit_id": "11256",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/eml"
-          },
-          "migration_wp__labs__emplus": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "emplus",
-                      "plugin:epfl_accred:unit_id": "13477",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/emplus"
-          },
-          "migration_wp__labs__emsi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "emsi",
-                      "plugin:epfl_accred:unit_id": "13346",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/emsi"
-          },
-          "migration_wp__labs__enac_am": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "enac-am",
-                      "plugin:epfl_accred:unit_id": "17",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/enac-am"
-          },
-          "migration_wp__labs__enacit2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "enac-it",
-                      "plugin:epfl_accred:unit_id": "10208",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/enacit2"
-          },
-          "migration_wp__labs__entc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "entc",
-                      "plugin:epfl_accred:unit_id": "11255",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/entc"
-          },
-          "migration_wp__labs__epsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "epsl",
-                      "plugin:epfl_accred:unit_id": "12330",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/epsl"
-          },
-          "migration_wp__labs__esl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "esl",
-                      "plugin:epfl_accred:unit_id": "11977",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/esl"
-          },
-          "migration_wp__labs__expertise": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "LEURE",
-                      "plugin:epfl_accred:unit_id": "10252",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/expertise"
-          },
-          "migration_wp__labs__fellay_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-fe",
-                      "plugin:epfl_accred:unit_id": "12477",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/fellay-lab"
-          },
-          "migration_wp__labs__ffo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-dd",
-                      "plugin:epfl_accred:unit_id": "13276",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ffo"
-          },
-          "migration_wp__labs__fimap": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "fimap",
-                      "plugin:epfl_accred:unit_id": "12702",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/fimap"
-          },
-          "migration_wp__labs__flexlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "flexlab",
-                      "plugin:epfl_accred:unit_id": "13471",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/flexlab"
-          },
-          "migration_wp__labs__form": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "form",
-                      "plugin:epfl_accred:unit_id": "12812",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/form"
-          },
-          "migration_wp__labs__fsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "fsl",
-                      "plugin:epfl_accred:unit_id": "13203",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/fsl"
-          },
-          "migration_wp__labs__galatea": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "galatea",
-                      "plugin:epfl_accred:unit_id": "13016",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/galatea"
-          },
-          "migration_wp__labs__gel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gel",
-                      "plugin:epfl_accred:unit_id": "13064",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gel"
-          },
-          "migration_wp__labs__gem": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-jvh",
-                      "plugin:epfl_accred:unit_id": "12692",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gem"
-          },
-          "migration_wp__labs__gemini_e3": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "leure",
-                      "plugin:epfl_accred:unit_id": "10252",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gemini-e3"
-          },
-          "migration_wp__labs__genomic_resources": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lasig",
-                      "plugin:epfl_accred:unit_id": "10244",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/genomic-resources"
-          },
-          "migration_wp__labs__gfo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-lt",
-                      "plugin:epfl_accred:unit_id": "12146",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gfo"
-          },
-          "migration_wp__labs__gis": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gis-ge",
-                      "plugin:epfl_accred:unit_id": "12118",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gis"
-          },
-          "migration_wp__labs__gonczy_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upgon",
-                      "plugin:epfl_accred:unit_id": "11155",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gonczy-lab"
-          },
-          "migration_wp__labs__gr_cel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-cel",
-                      "plugin:epfl_accred:unit_id": "11838",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gr-cel"
-          },
-          "migration_wp__labs__gr_tes": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "egg",
-                      "plugin:epfl_accred:unit_id": "11822",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gr-tes"
-          },
-          "migration_wp__labs__graefflab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upgraeff",
-                      "plugin:epfl_accred:unit_id": "12824",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/graefflab"
-          },
-          "migration_wp__labs__gramm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-mm",
-                      "plugin:epfl_accred:unit_id": "12149",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/gramm"
-          },
-          "migration_wp__labs__grpi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-pi",
-                      "plugin:epfl_accred:unit_id": "12392",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/grpi"
-          },
-          "migration_wp__labs__habitat": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lab-u",
-                      "plugin:epfl_accred:unit_id": "12780",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/habitat"
-          },
-          "migration_wp__labs__hanahan_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cmso",
-                      "plugin:epfl_accred:unit_id": "12095",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/hanahan-lab"
-          },
-          "migration_wp__labs__herus": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "herus",
-                      "plugin:epfl_accred:unit_id": "13132",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/herus"
-          },
-          "migration_wp__labs__hessbellwald_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uphess",
-                      "plugin:epfl_accred:unit_id": "13046",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/hessbellwald-lab"
-          },
-          "migration_wp__labs__het": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lptp",
-                      "plugin:epfl_accred:unit_id": "11425",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/het"
-          },
-          "migration_wp__labs__hl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-hl",
-                      "plugin:epfl_accred:unit_id": "12587",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/hl"
-          },
-          "migration_wp__labs__hobel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "hobel",
-                      "plugin:epfl_accred:unit_id": "13578",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/hobel"
-          },
-          "migration_wp__labs__huelsken_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uphuelsken",
-                      "plugin:epfl_accred:unit_id": "11259",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/huelsken-lab"
-          },
-          "migration_wp__labs__hummel_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uphummel",
-                      "plugin:epfl_accred:unit_id": "13320",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/hummel-lab"
-          },
-          "migration_wp__labs__iahr2020": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmh",
-                      "plugin:epfl_accred:unit_id": "10309",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/iahr2020"
-          },
-          "migration_wp__labs__ibois": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ibois",
-                      "plugin:epfl_accred:unit_id": "10236",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ibois"
-          },
-          "migration_wp__labs__iclab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "iclab",
-                      "plugin:epfl_accred:unit_id": "12701",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/iclab"
-          },
-          "migration_wp__labs__icnf2019": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "iclab",
-                      "plugin:epfl_accred:unit_id": "12701",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/icnf2019"
-          },
-          "migration_wp__labs__ict4sm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-dk",
-                      "plugin:epfl_accred:unit_id": "13059",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ict4sm"
-          },
-          "migration_wp__labs__ideas": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "last",
-                      "plugin:epfl_accred:unit_id": "12329",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ideas"
-          },
-          "migration_wp__labs__idiap": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lidiap",
-                      "plugin:epfl_accred:unit_id": "10381",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/idiap"
-          },
-          "migration_wp__labs__iig": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-ic-rb",
-                      "plugin:epfl_accred:unit_id": "12345",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/iig"
-          },
-          "migration_wp__labs__imac": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "imac",
-                      "plugin:epfl_accred:unit_id": "10237",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/imac"
-          },
-          "migration_wp__labs__innoseed_enac": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "enac-inno",
-                      "plugin:epfl_accred:unit_id": "13324",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/innoseed-enac"
-          },
-          "migration_wp__labs__instantlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "instant-lab",
-                      "plugin:epfl_accred:unit_id": "12651",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/instantlab"
-          },
-          "migration_wp__labs__ipese": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-fm",
-                      "plugin:epfl_accred:unit_id": "12691",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ipese"
-          },
-          "migration_wp__labs__iphys_it": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "iphys-ge",
-                      "plugin:epfl_accred:unit_id": "13150",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/iphys-it"
-          },
-          "migration_wp__labs__isic": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "isic",
-                      "plugin:epfl_accred:unit_id": "10095",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/isic"
-          },
-          "migration_wp__labs__ivrl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ivrl",
-                      "plugin:epfl_accred:unit_id": "10429",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ivrl"
-          },
-          "migration_wp__labs__k_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpqm1",
-                      "plugin:epfl_accred:unit_id": "11892",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/k-lab"
-          },
-          "migration_wp__labs__la": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "la3",
-                      "plugin:epfl_accred:unit_id": "12397",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/la"
-          },
-          "migration_wp__labs__lab_u": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lab-u",
-                      "plugin:epfl_accred:unit_id": "12780",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lab-u"
-          },
-          "migration_wp__labs__laba": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "laba",
-                      "plugin:epfl_accred:unit_id": "11188",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/laba"
-          },
-          "migration_wp__labs__labos": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "labos",
-                      "plugin:epfl_accred:unit_id": "10700",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/labos"
-          },
-          "migration_wp__labs__lacal": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lacal",
-                      "plugin:epfl_accred:unit_id": "11265",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lacal"
-          },
-          "migration_wp__labs__lai": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lai",
-                      "plugin:epfl_accred:unit_id": "10351",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lai"
-          },
-          "migration_wp__labs__lammm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lammm",
-                      "plugin:epfl_accred:unit_id": "12614",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lammm"
-          },
-          "migration_wp__labs__lamp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lamp1",
-                      "plugin:epfl_accred:unit_id": "10409",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lamp"
-          },
-          "migration_wp__labs__lams_next": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lams",
-                      "plugin:epfl_accred:unit_id": "10412",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lams-next"
-          },
-          "migration_wp__labs__lanes": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lanes",
-                      "plugin:epfl_accred:unit_id": "11840",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lanes"
-          },
-          "migration_wp__labs__lap": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lap",
-                      "plugin:epfl_accred:unit_id": "10418",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lap"
-          },
-          "migration_wp__labs__lapd": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lapd",
-                      "plugin:epfl_accred:unit_id": "12209",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lapd"
-          },
-          "migration_wp__labs__lapi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lapi",
-                      "plugin:epfl_accred:unit_id": "13601",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lapi"
-          },
-          "migration_wp__labs__lapis": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lapis",
-                      "plugin:epfl_accred:unit_id": "12759",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lapis"
-          },
-          "migration_wp__labs__lasa": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lasa",
-                      "plugin:epfl_accred:unit_id": "10660",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lasa"
-          },
-          "migration_wp__labs__lashuel_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmnn",
-                      "plugin:epfl_accred:unit_id": "11104",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lashuel-lab"
-          },
-          "migration_wp__labs__lasig": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lasig",
-                      "plugin:epfl_accred:unit_id": "10244",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lasig"
-          },
-          "migration_wp__labs__laspe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "laspe",
-                      "plugin:epfl_accred:unit_id": "10946",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/laspe"
-          },
-          "migration_wp__labs__last": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "last",
-                      "plugin:epfl_accred:unit_id": "12329",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/last"
-          },
-          "migration_wp__labs__lastro": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lastro",
-                      "plugin:epfl_accred:unit_id": "10933",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lastro"
-          },
-          "migration_wp__labs__lasur": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lasur",
-                      "plugin:epfl_accred:unit_id": "10241",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lasur"
-          },
-          "migration_wp__labs__lbe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lbe",
-                      "plugin:epfl_accred:unit_id": "10268",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lbe"
-          },
-          "migration_wp__labs__lbm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "updalpe",
-                      "plugin:epfl_accred:unit_id": "11830",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lbm"
-          },
-          "migration_wp__labs__lbni": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lbni",
-                      "plugin:epfl_accred:unit_id": "12183",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lbni"
-          },
-          "migration_wp__labs__lbo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lbo",
-                      "plugin:epfl_accred:unit_id": "10299",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lbo"
-          },
-          "migration_wp__labs__lbp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lbp",
-                      "plugin:epfl_accred:unit_id": "12398",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lbp"
-          },
-          "migration_wp__labs__lbs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lbs",
-                      "plugin:epfl_accred:unit_id": "10871",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lbs"
-          },
-          "migration_wp__labs__lcav": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lcav",
-                      "plugin:epfl_accred:unit_id": "10434",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lcav"
-          },
-          "migration_wp__labs__lcc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lcc",
-                      "plugin:epfl_accred:unit_id": "10226",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lcc"
-          },
-          "migration_wp__labs__lce": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lce",
-                      "plugin:epfl_accred:unit_id": "11718",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lce"
-          },
-          "migration_wp__labs__lch": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pl-lch",
-                      "plugin:epfl_accred:unit_id": "10263",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "de",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lch"
-          },
-          "migration_wp__labs__lcn": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lcn1",
-                      "plugin:epfl_accred:unit_id": "10416",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lcn"
-          },
-          "migration_wp__labs__lcpm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lcpm",
-                      "plugin:epfl_accred:unit_id": "10106",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lcpm"
-          },
-          "migration_wp__labs__lcvmm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lcvmm",
-                      "plugin:epfl_accred:unit_id": "10163",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lcvmm"
-          },
-          "migration_wp__labs__ldm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ldm1",
-                      "plugin:epfl_accred:unit_id": "11268",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ldm"
-          },
-          "migration_wp__labs__leago": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "leago",
-                      "plugin:epfl_accred:unit_id": "13603",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/leago"
-          },
-          "migration_wp__labs__leb": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "leb",
-                      "plugin:epfl_accred:unit_id": "12031",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/leb"
-          },
-          "migration_wp__labs__lemaitrelab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uplem",
-                      "plugin:epfl_accred:unit_id": "11772",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lemaitrelab"
-          },
-          "migration_wp__labs__lemr": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lemr",
-                      "plugin:epfl_accred:unit_id": "13063",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lemr"
-          },
-          "migration_wp__labs__len": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "len",
-                      "plugin:epfl_accred:unit_id": "10457",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/len"
-          },
-          "migration_wp__labs__leso": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "leso-pb",
-                      "plugin:epfl_accred:unit_id": "10262",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/leso"
-          },
-          "migration_wp__labs__leure": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "LEURE",
-                      "plugin:epfl_accred:unit_id": "10252",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/leure"
-          },
-          "migration_wp__labs__lfmi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lfmi",
-                      "plugin:epfl_accred:unit_id": "12052",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lfmi"
-          },
-          "migration_wp__labs__lgb": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lgb",
-                      "plugin:epfl_accred:unit_id": "12552",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lgb"
-          },
-          "migration_wp__labs__lhtc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lhtc",
-                      "plugin:epfl_accred:unit_id": "11843",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lhtc"
-          },
-          "migration_wp__labs__lifmet": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lifmet",
-                      "plugin:epfl_accred:unit_id": "10984",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lifmet"
-          },
-          "migration_wp__labs__lingner_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uplin",
-                      "plugin:epfl_accred:unit_id": "11159",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lingner-lab"
-          },
-          "migration_wp__labs__linx": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "linx",
-                      "plugin:epfl_accred:unit_id": "12434",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/linx"
-          },
-          "migration_wp__labs__lions": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lions",
-                      "plugin:epfl_accred:unit_id": "12179",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lions"
-          },
-          "migration_wp__labs__lipid": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lipid",
-                      "plugin:epfl_accred:unit_id": "12325",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lipid"
-          },
-          "migration_wp__labs__lis": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lis",
-                      "plugin:epfl_accred:unit_id": "10370",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lis"
-          },
-          "migration_wp__labs__lmaf": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmaf",
-                      "plugin:epfl_accred:unit_id": "10367",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmaf"
-          },
-          "migration_wp__labs__lmam": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmam",
-                      "plugin:epfl_accred:unit_id": "10303",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmam"
-          },
-          "migration_wp__labs__lmc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmc",
-                      "plugin:epfl_accred:unit_id": "10341",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmc"
-          },
-          "migration_wp__labs__lmgn": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmgn",
-                      "plugin:epfl_accred:unit_id": "13021",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmgn"
-          },
-          "migration_wp__labs__lmh": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmh",
-                      "plugin:epfl_accred:unit_id": "10309",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmh"
-          },
-          "migration_wp__labs__lmis1": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmis1",
-                      "plugin:epfl_accred:unit_id": "10321",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmis1"
-          },
-          "migration_wp__labs__lmis2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmis2",
-                      "plugin:epfl_accred:unit_id": "10322",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmis2"
-          },
-          "migration_wp__labs__lmis4": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmis4",
-                      "plugin:epfl_accred:unit_id": "10324",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmis4"
-          },
-          "migration_wp__labs__lmm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmm",
-                      "plugin:epfl_accred:unit_id": "10336",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmm"
-          },
-          "migration_wp__labs__lmom": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmom",
-                      "plugin:epfl_accred:unit_id": "12015",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmom"
-          },
-          "migration_wp__labs__lms": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lms",
-                      "plugin:epfl_accred:unit_id": "10264",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lms"
-          },
-          "migration_wp__labs__lmsc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmsc",
-                      "plugin:epfl_accred:unit_id": "11832",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmsc"
-          },
-          "migration_wp__labs__lmtm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmtm",
-                      "plugin:epfl_accred:unit_id": "12903",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmtm"
-          },
-          "migration_wp__labs__lmts": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmts",
-                      "plugin:epfl_accred:unit_id": "10955",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lmts"
-          },
-          "migration_wp__labs__lnb": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lnb",
-                      "plugin:epfl_accred:unit_id": "12909",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lnb"
-          },
-          "migration_wp__labs__lnce": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lnce",
-                      "plugin:epfl_accred:unit_id": "13077",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lnce"
-          },
-          "migration_wp__labs__lnco": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lnco",
-                      "plugin:epfl_accred:unit_id": "11025",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lnco"
-          },
-          "migration_wp__labs__lnd": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lnd",
-                      "plugin:epfl_accred:unit_id": "13266",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lnd"
-          },
-          "migration_wp__labs__lne": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lne",
-                      "plugin:epfl_accred:unit_id": "13047",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lne"
-          },
-          "migration_wp__labs__lns": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lns",
-                      "plugin:epfl_accred:unit_id": "10150",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lns"
-          },
-          "migration_wp__labs__lo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lo",
-                      "plugin:epfl_accred:unit_id": "11723",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lo"
-          },
-          "migration_wp__labs__lp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lp",
-                      "plugin:epfl_accred:unit_id": "10342",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lp"
-          },
-          "migration_wp__labs__lpac": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpac",
-                      "plugin:epfl_accred:unit_id": "13295",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpac"
-          },
-          "migration_wp__labs__lpap": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpap",
-                      "plugin:epfl_accred:unit_id": "10658",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpap"
-          },
-          "migration_wp__labs__lpbs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpbs",
-                      "plugin:epfl_accred:unit_id": "13565",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpbs"
-          },
-          "migration_wp__labs__lpdi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpdi",
-                      "plugin:epfl_accred:unit_id": "13000",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpdi"
-          },
-          "migration_wp__labs__lphe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lphe1",
-                      "plugin:epfl_accred:unit_id": "10863",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lphe"
-          },
-          "migration_wp__labs__lpi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpi",
-                      "plugin:epfl_accred:unit_id": "10101",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpi"
-          },
-          "migration_wp__labs__lpmat": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpmat",
-                      "plugin:epfl_accred:unit_id": "12141",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpmat"
-          },
-          "migration_wp__labs__lpmc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpmc",
-                      "plugin:epfl_accred:unit_id": "10142",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpmc"
-          },
-          "migration_wp__labs__lpmn": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpmn",
-                      "plugin:epfl_accred:unit_id": "10149",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpmn"
-          },
-          "migration_wp__labs__lpmv": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpmv",
-                      "plugin:epfl_accred:unit_id": "10868",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpmv"
-          },
-          "migration_wp__labs__lpn": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpn",
-                      "plugin:epfl_accred:unit_id": "10158",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lpn"
-          },
-          "migration_wp__labs__lppc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lppc",
-                      "plugin:epfl_accred:unit_id": "10869",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lppc"
-          },
-          "migration_wp__labs__lppt": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lppt",
-                      "plugin:epfl_accred:unit_id": "11959",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lppt"
-          },
-          "migration_wp__labs__lptp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lptp",
-                      "plugin:epfl_accred:unit_id": "11425",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lptp"
-          },
-          "migration_wp__labs__lqg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lqg",
-                      "plugin:epfl_accred:unit_id": "13289",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lqg"
-          },
-          "migration_wp__labs__lqm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lqm",
-                      "plugin:epfl_accred:unit_id": "11706",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lqm"
-          },
-          "migration_wp__labs__lqno": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-ga",
-                      "plugin:epfl_accred:unit_id": "13462",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lqno"
-          },
-          "migration_wp__labs__lrese": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lrese",
-                      "plugin:epfl_accred:unit_id": "12656",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lrese"
-          },
-          "migration_wp__labs__lrm": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lrm",
-                      "plugin:epfl_accred:unit_id": "12975",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lrm"
-          },
-          "migration_wp__labs__lrs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lrs",
-                      "plugin:epfl_accred:unit_id": "12619",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lrs"
-          },
-          "migration_wp__labs__lsbi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsbi",
-                      "plugin:epfl_accred:unit_id": "12393",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsbi"
-          },
-          "migration_wp__labs__lse": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sb-mg",
-                      "plugin:epfl_accred:unit_id": "13463",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lse"
-          },
-          "migration_wp__labs__lsen": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsen",
-                      "plugin:epfl_accred:unit_id": "10152",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsen"
-          },
-          "migration_wp__labs__lsi": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsi1",
-                      "plugin:epfl_accred:unit_id": "11140",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsi"
-          },
-          "migration_wp__labs__lsir": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsir",
-                      "plugin:epfl_accred:unit_id": "10405",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsir"
-          },
-          "migration_wp__labs__lsis": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sv-it",
-                      "plugin:epfl_accred:unit_id": "10452",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsis"
-          },
-          "migration_wp__labs__lsme": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsme",
-                      "plugin:epfl_accred:unit_id": "11814",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsme"
-          },
-          "migration_wp__labs__lsms": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsms",
-                      "plugin:epfl_accred:unit_id": "10232",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsms"
-          },
-          "migration_wp__labs__lsp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ph-ic",
-                      "plugin:epfl_accred:unit_id": "11900",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsp"
-          },
-          "migration_wp__labs__lsym": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lsym",
-                      "plugin:epfl_accred:unit_id": "11233",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lsym"
-          },
-          "migration_wp__labs__lte": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lte",
-                      "plugin:epfl_accred:unit_id": "11534",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lte"
-          },
-          "migration_wp__labs__lth3": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lth3",
-                      "plugin:epfl_accred:unit_id": "10228",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lth3"
-          },
-          "migration_wp__labs__ltqe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ltqe",
-                      "plugin:epfl_accred:unit_id": "12400",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ltqe"
-          },
-          "migration_wp__labs__lts4": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lts4",
-                      "plugin:epfl_accred:unit_id": "10851",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lts4"
-          },
-          "migration_wp__labs__lts5www": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lts5",
-                      "plugin:epfl_accred:unit_id": "10954",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lts5www"
-          },
-          "migration_wp__labs__lumes": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lumes",
-                      "plugin:epfl_accred:unit_id": "12311",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lumes"
-          },
-          "migration_wp__labs__luts": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "luts",
-                      "plugin:epfl_accred:unit_id": "12124",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/luts"
-          },
-          "migration_wp__labs__lwe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lwe",
-                      "plugin:epfl_accred:unit_id": "13119",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/lwe"
-          },
-          "migration_wp__labs__mag": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-as",
-                      "plugin:epfl_accred:unit_id": "13307",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mag"
-          },
-          "migration_wp__labs__manslab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "manslab-co",
-                      "plugin:epfl_accred:unit_id": "12761",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/manslab"
-          },
-          "migration_wp__labs__markram_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lnmc",
-                      "plugin:epfl_accred:unit_id": "10458",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/markram-lab"
-          },
-          "migration_wp__labs__master_architecture": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sar-d",
-                      "plugin:epfl_accred:unit_id": "10564",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/master-architecture"
-          },
-          "migration_wp__labs__mccabelab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upmccabe",
-                      "plugin:epfl_accred:unit_id": "13082",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mccabelab"
-          },
-          "migration_wp__labs__mckinney_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upkin",
-                      "plugin:epfl_accred:unit_id": "11741",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mckinney-lab"
-          },
-          "migration_wp__labs__mcs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "mcs",
-                      "plugin:epfl_accred:unit_id": "10231",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mcs"
-          },
-          "migration_wp__labs__mechanical_spectroscopy": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lpmc",
-                      "plugin:epfl_accred:unit_id": "10142",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mechanical-spectroscopy"
-          },
-          "migration_wp__labs__meylan_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upmeylan",
-                      "plugin:epfl_accred:unit_id": "12436",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/meylan-lab"
-          },
-          "migration_wp__labs__mhmc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lp",
-                      "plugin:epfl_accred:unit_id": "10342",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mhmc"
-          },
-          "migration_wp__labs__microbs": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "microbs",
-                      "plugin:epfl_accred:unit_id": "13117",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/microbs"
-          },
-          "migration_wp__labs__mir": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "mir",
-                      "plugin:epfl_accred:unit_id": "12065",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mir"
-          },
-          "migration_wp__labs__mlo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "mlo",
-                      "plugin:epfl_accred:unit_id": "13319",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mlo"
-          },
-          "migration_wp__labs__mmspg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-eb",
-                      "plugin:epfl_accred:unit_id": "11889",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mmspg"
-          },
-          "migration_wp__labs__mns": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "mns",
-                      "plugin:epfl_accred:unit_id": "13308",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/mns"
-          },
-          "migration_wp__labs__naef_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upnae",
-                      "plugin:epfl_accred:unit_id": "11260",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/naef-lab"
-          },
-          "migration_wp__labs__nal": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "nal",
-                      "plugin:epfl_accred:unit_id": "12550",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nal"
-          },
-          "migration_wp__labs__nanolab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "nanolab",
-                      "plugin:epfl_accred:unit_id": "10328",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nanolab"
-          },
-          "migration_wp__labs__naveiras_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-naveiras",
-                      "plugin:epfl_accred:unit_id": "12818",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/naveiras-lab"
-          },
-          "migration_wp__labs__nems": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "nems",
-                      "plugin:epfl_accred:unit_id": "12739",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nems"
-          },
-          "migration_wp__labs__nextgen": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lasig",
-                      "plugin:epfl_accred:unit_id": "10244",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nextgen"
-          },
-          "migration_wp__labs__nm2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "bbp-core",
-                      "plugin:epfl_accred:unit_id": "11230",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nm2"
-          },
-          "migration_wp__labs__nolossproject": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "nam",
-                      "plugin:epfl_accred:unit_id": "10373",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nolossproject"
-          },
-          "migration_wp__labs__nsbl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-laman",
-                      "plugin:epfl_accred:unit_id": "13622",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/nsbl"
-          },
-          "migration_wp__labs__ntcm2018": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lmgn",
-                      "plugin:epfl_accred:unit_id": "13021",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ntcm2018"
-          },
-          "migration_wp__labs__oateslab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upoates",
-                      "plugin:epfl_accred:unit_id": "13325",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/oateslab"
-          },
-          "migration_wp__labs__pbl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pbl",
-                      "plugin:epfl_accred:unit_id": "13293",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/pbl"
-          },
-          "migration_wp__labs__pcsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pcsl",
-                      "plugin:epfl_accred:unit_id": "13087",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/pcsl"
-          },
-          "migration_wp__labs__pde": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pde",
-                      "plugin:epfl_accred:unit_id": "12235",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/pde"
-          },
-          "migration_wp__labs__pel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pel",
-                      "plugin:epfl_accred:unit_id": "12902",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/pel"
-          },
-          "migration_wp__labs__persat_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uppersat",
-                      "plugin:epfl_accred:unit_id": "13303",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/persat-lab"
-          },
-          "migration_wp__labs__phosl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "phosl",
-                      "plugin:epfl_accred:unit_id": "12394",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/phosl"
-          },
-          "migration_wp__labs__pixe": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "iic-ge",
-                      "plugin:epfl_accred:unit_id": "10230",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/pixe"
-          },
-          "migration_wp__labs__plte": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "enac-plte",
-                      "plugin:epfl_accred:unit_id": "13355",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/plte"
-          },
-          "migration_wp__labs__powerlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "powerlab",
-                      "plugin:epfl_accred:unit_id": "13020",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/powerlab"
-          },
-          "migration_wp__labs__prob": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "prob",
-                      "plugin:epfl_accred:unit_id": "10123",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/prob"
-          },
-          "migration_wp__labs__prst": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "prst",
-                      "plugin:epfl_accred:unit_id": "10128",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/prst"
-          },
-          "migration_wp__labs__ptbtg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "ptbtg",
-                      "plugin:epfl_accred:unit_id": "13474",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ptbtg"
-          },
-          "migration_wp__labs__pvlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pv-lab",
-                      "plugin:epfl_accred:unit_id": "11963",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/pvlab"
-          },
-          "migration_wp__labs__q_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-qua",
-                      "plugin:epfl_accred:unit_id": "13060",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/q-lab"
-          },
-          "migration_wp__labs__radtke_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uprad",
-                      "plugin:epfl_accred:unit_id": "11429",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/radtke-lab"
-          },
-          "migration_wp__labs__ramdya_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upramdya",
-                      "plugin:epfl_accred:unit_id": "13360",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ramdya-lab"
-          },
-          "migration_wp__labs__rao": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "rao",
-                      "plugin:epfl_accred:unit_id": "12788",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/rao"
-          },
-          "migration_wp__labs__react": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-dg",
-                      "plugin:epfl_accred:unit_id": "12390",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/react"
-          },
-          "migration_wp__labs__resslab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "resslab",
-                      "plugin:epfl_accred:unit_id": "10233",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/resslab"
-          },
-          "migration_wp__labs__rfic": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-cd",
-                      "plugin:epfl_accred:unit_id": "12148",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/rfic"
-          },
-          "migration_wp__labs__rrl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "rrl",
-                      "plugin:epfl_accred:unit_id": "12520",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/rrl"
-          },
-          "migration_wp__labs__sber": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sber",
-                      "plugin:epfl_accred:unit_id": "13006",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/sber"
-          },
-          "migration_wp__labs__scaffolds2018": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "alice",
-                      "plugin:epfl_accred:unit_id": "11533",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/scaffolds2018"
-          },
-          "migration_wp__labs__schoonjans_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upschoonjans",
-                      "plugin:epfl_accred:unit_id": "12735",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/schoonjans-lab"
-          },
-          "migration_wp__labs__sci_sb_rh": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sb-rh",
-                      "plugin:epfl_accred:unit_id": "13466",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/sci-sb-rh"
-          },
-          "migration_wp__labs__servicedesk_sandbox": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "exdesk",
-                      "plugin:epfl_accred:unit_id": "13034",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/servicedesk-sandbox"
-          },
-          "migration_wp__labs__simanis_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "upsim",
-                      "plugin:epfl_accred:unit_id": "11430",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/simanis-lab"
-          },
-          "migration_wp__labs__skil": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "enac-do",
-                      "plugin:epfl_accred:unit_id": "10203",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/skil"
-          },
-          "migration_wp__labs__smal": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "smal",
-                      "plugin:epfl_accred:unit_id": "12820",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/smal"
-          },
-          "migration_wp__labs__smat": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "smat",
-                      "plugin:epfl_accred:unit_id": "11798",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/smat"
-          },
-          "migration_wp__labs__sois": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "gr-dil",
-                      "plugin:epfl_accred:unit_id": "12770",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/sois"
-          },
-          "migration_wp__labs__spc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "spc-ge",
-                      "plugin:epfl_accred:unit_id": "12266",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/spc"
-          },
-          "migration_wp__labs__spring": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "spring",
-                      "plugin:epfl_accred:unit_id": "13548",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/spring"
-          },
-          "migration_wp__labs__sps": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sps",
-                      "plugin:epfl_accred:unit_id": "13022",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/sps"
-          },
-          "migration_wp__labs__stap": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "stap",
-                      "plugin:epfl_accred:unit_id": "10127",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/stap"
-          },
-          "migration_wp__labs__stat": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "stat",
-                      "plugin:epfl_accred:unit_id": "10124",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/stat"
-          },
-          "migration_wp__labs__sunmil": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sunmil",
-                      "plugin:epfl_accred:unit_id": "12173",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/sunmil"
-          },
-          "migration_wp__labs__sxl2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sxl",
-                      "plugin:epfl_accred:unit_id": "13216",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/sxl2"
-          },
-          "migration_wp__labs__tan": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "tan",
-                      "plugin:epfl_accred:unit_id": "11828",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tan"
-          },
-          "migration_wp__labs__tang_lab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lbi",
-                      "plugin:epfl_accred:unit_id": "13294",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tang-lab"
-          },
-          "migration_wp__labs__tcl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "tcl",
-                      "plugin:epfl_accred:unit_id": "12395",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tcl"
-          },
-          "migration_wp__labs__tebel": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "tebel",
-                      "plugin:epfl_accred:unit_id": "13545",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tebel"
-          },
-          "migration_wp__labs__test_medias": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "csqi",
-                      "plugin:epfl_accred:unit_id": "12495",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/test-medias"
-          },
-          "migration_wp__labs__test_polylex": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "csqi",
-                      "plugin:epfl_accred:unit_id": "12495",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/test-polylex"
-          },
-          "migration_wp__labs__test_slug": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "csqi",
-                      "plugin:epfl_accred:unit_id": "12495",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/test-slug"
-          },
-          "migration_wp__labs__theos": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "theos",
-                      "plugin:epfl_accred:unit_id": "12411",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/theos"
-          },
-          "migration_wp__labs__tic": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-sm",
-                      "plugin:epfl_accred:unit_id": "12151",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tic"
-          },
-          "migration_wp__labs__topo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "topo",
-                      "plugin:epfl_accred:unit_id": "10249",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/topo"
-          },
-          "migration_wp__labs__tox": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "tox",
-                      "plugin:epfl_accred:unit_id": "12482",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tox"
-          },
-          "migration_wp__labs__tsam": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "tsam",
-                      "plugin:epfl_accred:unit_id": "11768",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/tsam"
-          },
-          "migration_wp__labs__unfold": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "unfold",
-                      "plugin:epfl_accred:unit_id": "13018",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/unfold"
-          },
-          "migration_wp__labs__urbangene": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "lasig",
-                      "plugin:epfl_accred:unit_id": "10244",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/urbangene"
-          },
-          "migration_wp__labs__vdg": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "vdg",
-                      "plugin:epfl_accred:unit_id": "11271",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/vdg"
-          },
-          "migration_wp__labs__vita": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "vita",
-                      "plugin:epfl_accred:unit_id": "13529",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/vita"
-          },
-          "migration_wp__labs__vlsc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "VLSC",
-                      "plugin:epfl_accred:unit_id": "12814",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/vlsc"
-          },
-          "migration_wp__labs__wire": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "wire",
-                      "plugin:epfl_accred:unit_id": "12172",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/wire"
-          },
-          "migration_wp__labs__ytm2019": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uphess",
-                      "plugin:epfl_accred:unit_id": "13046",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ytm2019"
-          },
-          "migration_wp__labs__ytm2019_test_hugo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "uphess",
-                      "plugin:epfl_accred:unit_id": "13046",
-                      "stylesheet": "wp-theme-light"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "labs/ytm2019_test_hugo"
-          },
-          "migration_wp__lulu__gfo": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-lt",
-                      "plugin:epfl_accred:unit_id": "12146",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "lulu/gfo"
-          },
-          "migration_wp__polylex": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "aj",
-                      "plugin:epfl_accred:unit_id": "10005",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "polylex"
-          },
-          "migration_wp__polylex2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "aj",
-                      "plugin:epfl_accred:unit_id": "10005",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "migration-wp.epfl.ch",
-              "wp_path": "polylex2"
-          },
-          "no_local_env__dcsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "dcsl",
-                      "plugin:epfl_accred:unit_id": "12634",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "gcharmier",
-              "wp_hostname": "no-local-env",
-              "wp_path": "dcsl"
-          },
-          "test_wp": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "ScienceQA",
-                      "plugin:epfl_accred:unit": "mediacom",
-                      "plugin:epfl_accred:unit_id": "12999",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": ""
-          },
-          "test_wp__campus__services": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "vpsi",
-                      "plugin:epfl_accred:unit_id": "12637",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "campus/services"
-          },
-          "test_wp__labs__cvlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "cvlab",
-                      "plugin:epfl_accred:unit_id": "10659",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "labs/cvlab"
-          },
-          "test_wp__labs__dcsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "dcsl",
-                      "plugin:epfl_accred:unit_id": "12634",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "labs/dcsl"
-          },
-          "test_wp__labs__emc": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "sci-sti-fr",
-                      "plugin:epfl_accred:unit_id": "12147",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "labs/emc"
-          },
-          "test_wp__labs__la": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "la3",
-                      "plugin:epfl_accred:unit_id": "12397",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "labs/la"
-          },
-          "test_wp__labs__last": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "last",
-                      "plugin:epfl_accred:unit_id": "12329",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en",
-                          "fr"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "labs/last"
-          },
-          "test_wp__labs__pvlab": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "pv-lab",
-                      "plugin:epfl_accred:unit_id": "11963",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "labs/pvlab"
-          },
-          "test_wp__testlulu": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": "GeneralPublic",
-                      "plugin:epfl_accred:unit": "idev-ing",
-                      "plugin:epfl_accred:unit_id": "13031",
-                      "stylesheet": "wp-theme-2018"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "test-wp.epfl.ch",
-              "wp_path": "testlulu"
-          },
-          "wp1_os_exopge__dcsl": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "DCSL",
-                      "plugin:epfl_accred:unit_id": "12634",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "wp1-os-exopge.epfl.ch",
-              "wp_path": "dcsl"
-          },
-          "wp1_os_exopge__galatea": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "GALATEA",
-                      "plugin:epfl_accred:unit_id": "13016",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "int",
-              "wp_hostname": "wp1-os-exopge.epfl.ch",
-              "wp_path": "galatea"
-          },
-          "wp5_os_exopge__site10": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site10/wp-includes/pomo/plural-forms.php on line 210\\n', b\"Warning: mysqli_real_connect(): (HY000/1045): Access denied for user 'qjgake3330ujib6v'@'10.180.21.25' (using password: YES) in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site10/wp-includes/wp-db.php on line 1531\\n\", b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site10/wp-includes/pomo/plural-forms.php on line 210\\n', b\"Warning: mysqli_real_connect(): (HY000/1045): Access denied for user 'qjgake3330ujib6v'@'10.180.21.25' (using password: YES) in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site10/wp-includes/wp-db.php on line 1531\\n\", b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "wp5-os-exopge.epfl.ch",
-              "wp_path": "site10"
-          },
-          "wp5_os_exopge__site11": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "_error": "Error getting options: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site11/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site11/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']",
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": null,
-                      "plugin:epfl_accred:unit_id": null,
-                      "stylesheet": null
-                  },
-                  "polylang": {
-                      "_error": "Error getting lang list: ERROR: [b'PHP Warning:  \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site11/wp-includes/pomo/plural-forms.php on line 210\\n', b'Warning: \"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"? in /srv/dev/wp5-os-exopge.epfl.ch/htdocs/site11/wp-includes/pomo/plural-forms.php on line 210\\n', b'Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can\\xe2\\x80\\x99t contact the database server at `test-db-wwp.epfl.ch`. This could mean your host\\xe2\\x80\\x99s database server is down.\\n']"
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "wp5-os-exopge.epfl.ch",
-              "wp_path": "site11"
-          },
-          "wp5_os_exopge__test": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "unit_name",
-                      "plugin:epfl_accred:unit_id": "unit_id",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "wp5-os-exopge.epfl.ch",
-              "wp_path": "test"
-          },
-          "wp5_os_exopge__test_varnish": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "None",
-                      "plugin:epfl_accred:unit_id": "None",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "wp5-os-exopge.epfl.ch",
-              "wp_path": "test_varnish"
-          },
-          "wp5_os_exopge__test_varnish2": {
-              "ansible_host": "test-ssh-wwp.epfl.ch",
-              "ansible_port": "32222",
-              "ansible_python_interpreter": "/usr/bin/python3",
-              "ansible_user": "www-data",
-              "openshift_namespace": "wwp-test",
-              "wp_details": {
-                  "options": {
-                      "epfl:site_category": null,
-                      "plugin:epfl_accred:unit": "None",
-                      "plugin:epfl_accred:unit_id": "None",
-                      "stylesheet": "epfl-master"
-                  },
-                  "polylang": {
-                      "langs": [
-                          "fr",
-                          "en"
-                      ]
-                  }
-              },
-              "wp_ensure_symlink_version": "5.2",
-              "wp_env": "dev",
-              "wp_hostname": "wp5-os-exopge.epfl.ch",
-              "wp_path": "test_varnish2"
+          "test_migration_wp__chaire_gaz_naturel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "chaire-gaz-naturel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/chaire-gaz-naturel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/chaire-gaz-naturel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"chaire-gaz-naturel\", \"categories\": [], \"theme\": \"epfl-master\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10264\", \"unit_name\": \"lms\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/chaire-gaz-naturel"
+          },
+          "test_migration_wp__emploi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "emploi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/emploi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/emploi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"emploi\", \"categories\": [], \"theme\": \"epfl-master\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10776\", \"unit_name\": \"rh-g\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/emploi"
+          },
+          "test_migration_wp__labs__aaa": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/aaa",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/aaa\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/aaa\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/aaa\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"13030\", \"unit_name\": \"idev-fsd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/aaa"
+          },
+          "test_migration_wp__labs__ablasserlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ablasserlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ablasserlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ablasserlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ablasserlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12938\", \"unit_name\": \"upablasser\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ablasserlab"
+          },
+          "test_migration_wp__labs__acces": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/acces",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/acces\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/acces\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/acces\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12385\", \"unit_name\": \"acces\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/acces"
+          },
+          "test_migration_wp__labs__acht": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/acht",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/acht\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/acht\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/acht\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13105\", \"unit_name\": \"acht\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/acht"
+          },
+          "test_migration_wp__labs__acm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/acm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/acm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/acm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/acm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10243\", \"unit_name\": \"gr-acm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/acm"
+          },
+          "test_migration_wp__labs__alice": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/alice",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/alice\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/alice\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/alice\", \"categories\": [\"Subscribe2\"], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"11533\", \"unit_name\": \"alice\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/alice"
+          },
+          "test_migration_wp__labs__alinek": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/alinek",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/alinek\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/alinek\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/alinek\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13031\", \"unit_name\": \"idev-ing\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/alinek"
+          },
+          "test_migration_wp__labs__amcv": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/amcv",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/amcv\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/amcv\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/amcv\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13587\", \"unit_name\": \"amcv\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/amcv"
+          },
+          "test_migration_wp__labs__anchp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/anchp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/anchp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/anchp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/anchp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12478\", \"unit_name\": \"anchp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/anchp"
+          },
+          "test_migration_wp__labs__anmath": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/anmath",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/anmath\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/anmath\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/anmath\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13393\", \"unit_name\": \"math-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/anmath"
+          },
+          "test_migration_wp__labs__anmc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/anmc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/anmc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/anmc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/anmc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11991\", \"unit_name\": \"anmc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/anmc"
+          },
+          "test_migration_wp__labs__apc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/apc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/apc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/apc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/apc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"12266\", \"unit_name\": \"spc-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/apc"
+          },
+          "test_migration_wp__labs__aphys": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/aphys",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/aphys\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/aphys\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/aphys\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12616\", \"unit_name\": \"aphys\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/aphys"
+          },
+          "test_migration_wp__labs__aprl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/aprl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/aprl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/aprl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/aprl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12574\", \"unit_name\": \"aprl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/aprl"
+          },
+          "test_migration_wp__labs__aqua": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/aqua",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/aqua\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/aqua\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/aqua\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12178\", \"unit_name\": \"aqua\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/aqua"
+          },
+          "test_migration_wp__labs__archizoom": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/archizoom",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/archizoom\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/archizoom\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/archizoom\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10565\", \"unit_name\": \"archizoom\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/archizoom"
+          },
+          "test_migration_wp__labs__aspg": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/aspg",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/aspg\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/aspg\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/aspg\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12150\", \"unit_name\": \"sci-sti-jmv\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/aspg"
+          },
+          "test_migration_wp__labs__auwerx_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/auwerx-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/auwerx-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/auwerx-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/auwerx-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11905\", \"unit_name\": \"lisp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/auwerx-lab"
+          },
+          "test_migration_wp__labs__barth_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/barth-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/barth-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/barth-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/barth-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13029\", \"unit_name\": \"idev-am\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/barth-lab"
+          },
+          "test_migration_wp__labs__biorob": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/biorob",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/biorob\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/biorob\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/biorob\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12165\", \"unit_name\": \"biorob\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/biorob"
+          },
+          "test_migration_wp__labs__bios": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/bios",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/bios\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/bios\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/bios\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12650\", \"unit_name\": \"bios\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/bios"
+          },
+          "test_migration_wp__labs__blokesch_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/blokesch-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/blokesch-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/blokesch-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/blokesch-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12076\", \"unit_name\": \"upblo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/blokesch-lab"
+          },
+          "test_migration_wp__labs__bpe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/bpe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/bpe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/bpe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/bpe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12053\", \"unit_name\": \"gr-gn\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/bpe"
+          },
+          "test_migration_wp__labs__brisken_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/brisken-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/brisken-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/brisken-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/brisken-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11257\", \"unit_name\": \"upbri\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/brisken-lab"
+          },
+          "test_migration_wp__labs__bucher_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/bucher-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/bucher-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/bucher-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/bucher-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11780\", \"unit_name\": \"gr-bucher\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/bucher-lab"
+          },
+          "test_migration_wp__labs__building2050": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/building2050",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/building2050\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/building2050\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/building2050\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13455\", \"unit_name\": \"build-o\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/building2050"
+          },
+          "test_migration_wp__labs__c3mp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/c3mp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/c3mp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/c3mp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/c3mp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12491\", \"unit_name\": \"c3mp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/c3mp"
+          },
+          "test_migration_wp__labs__cag": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cag",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cag\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cag\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cag\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13290\", \"unit_name\": \"cag\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cag"
+          },
+          "test_migration_wp__labs__cama": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cama",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cama\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cama\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cama\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12764\", \"unit_name\": \"cama\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cama"
+          },
+          "test_migration_wp__labs__cclab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cclab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cclab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cclab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cclab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10234\", \"unit_name\": \"cclab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cclab"
+          },
+          "test_migration_wp__labs__cdh_test": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cdh-test",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cdh-test\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cdh-test\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cdh-test\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10475\", \"unit_name\": \"cdh-di\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cdh-test"
+          },
+          "test_migration_wp__labs__cdt": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cdt",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cdt\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cdt\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cdt\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"11016\", \"unit_name\": \"ssie-ens\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cdt"
+          },
+          "test_migration_wp__labs__ceat": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ceat",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ceat\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ceat\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ceat\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10250\", \"unit_name\": \"ceat\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ceat"
+          },
+          "test_migration_wp__labs__cemi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cemi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cemi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cemi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cemi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11083\", \"unit_name\": \"mtei-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cemi"
+          },
+          "test_migration_wp__labs__cen": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cen",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cen\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cen\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cen\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"11809\", \"unit_name\": \"cen-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cen"
+          },
+          "test_migration_wp__labs__cgd": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cgd",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cgd\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cgd\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cgd\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10307\", \"unit_name\": \"igm-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cgd"
+          },
+          "test_migration_wp__labs__chaire_gaz_naturel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/chaire-gaz-naturel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/chaire-gaz-naturel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/chaire-gaz-naturel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/chaire-gaz-naturel\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10264\", \"unit_name\": \"lms\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/chaire-gaz-naturel"
+          },
+          "test_migration_wp__labs__clse": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/clse",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/clse\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/clse\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/clse\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12017\", \"unit_name\": \"clse\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/clse"
+          },
+          "test_migration_wp__labs__cnpa": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cnpa",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cnpa\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cnpa\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cnpa\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12781\", \"unit_name\": \"cnpa\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cnpa"
+          },
+          "test_migration_wp__labs__cole_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cole-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cole-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cole-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cole-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11742\", \"unit_name\": \"upcol\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cole-lab"
+          },
+          "test_migration_wp__labs__concours_alkindi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/concours-alkindi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/concours-alkindi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/concours-alkindi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/concours-alkindi\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"fr\"], \"unit_id\": \"10389\", \"unit_name\": \"ic-do\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/concours-alkindi"
+          },
+          "test_migration_wp__labs__constam_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/constam-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/constam-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/constam-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/constam-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11161\", \"unit_name\": \"upcda\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/constam-lab"
+          },
+          "test_migration_wp__labs__cosmo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cosmo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cosmo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cosmo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cosmo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12743\", \"unit_name\": \"cosmo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cosmo"
+          },
+          "test_migration_wp__labs__courtine_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/courtine-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/courtine-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/courtine-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/courtine-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12556\", \"unit_name\": \"upcourtine\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/courtine-lab"
+          },
+          "test_migration_wp__labs__cryos": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cryos",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cryos\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cryos\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cryos\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12533\", \"unit_name\": \"cryos\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cryos"
+          },
+          "test_migration_wp__labs__csqi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/csqi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/csqi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/csqi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/csqi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12495\", \"unit_name\": \"csqi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/csqi"
+          },
+          "test_migration_wp__labs__cvlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/cvlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/cvlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/cvlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/cvlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10659\", \"unit_name\": \"cvlab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/cvlab"
+          },
+          "test_migration_wp__labs__data": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/data",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/data\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/data\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/data\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12327\", \"unit_name\": \"data\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/data"
+          },
+          "test_migration_wp__labs__datathink": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/datathink",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/datathink\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/datathink\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/datathink\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"11533\", \"unit_name\": \"alice\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/datathink"
+          },
+          "test_migration_wp__labs__dcg": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dcg",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dcg\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dcg\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dcg\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11887\", \"unit_name\": \"dcg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dcg"
+          },
+          "test_migration_wp__labs__dcml": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dcml",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dcml\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dcml\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dcml\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13398\", \"unit_name\": \"dcml\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dcml"
+          },
+          "test_migration_wp__labs__dcsl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dcsl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dcsl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dcsl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dcsl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13031\", \"unit_name\": \"idev-ing\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dcsl"
+          },
+          "test_migration_wp__labs__dedis": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dedis",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dedis\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dedis\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dedis\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13061\", \"unit_name\": \"dedis\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dedis"
+          },
+          "test_migration_wp__labs__desl_pwrs": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/desl-pwrs",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/desl-pwrs\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/desl-pwrs\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/desl-pwrs\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12494\", \"unit_name\": \"desl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/desl-pwrs"
+          },
+          "test_migration_wp__labs__dhlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dhlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dhlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dhlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dhlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12632\", \"unit_name\": \"dhlab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dhlab"
+          },
+          "test_migration_wp__labs__dias": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dias",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dias\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dias\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dias\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11836\", \"unit_name\": \"dias\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dias"
+          },
+          "test_migration_wp__labs__digitalfutures": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/digitalfutures",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/digitalfutures\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/digitalfutures\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/digitalfutures\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"13327\", \"unit_name\": \"hrc-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/digitalfutures"
+          },
+          "test_migration_wp__labs__disal": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/disal",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/disal\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/disal\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/disal\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11904\", \"unit_name\": \"disal\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/disal"
+          },
+          "test_migration_wp__labs__disopt": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/disopt",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/disopt\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/disopt\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/disopt\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"11879\", \"unit_name\": \"disopt\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/disopt"
+          },
+          "test_migration_wp__labs__duboule_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/duboule-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/duboule-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/duboule-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/duboule-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"11705\", \"unit_name\": \"updub\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/duboule-lab"
+          },
+          "test_migration_wp__labs__dynnet": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/dynnet",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/dynnet\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/dynnet\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/dynnet\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11900\", \"unit_name\": \"ph-ic\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/dynnet"
+          },
+          "test_migration_wp__labs__east": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/east",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/east\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/east\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/east\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12813\", \"unit_name\": \"east-co\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/east"
+          },
+          "test_migration_wp__labs__echo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/echo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/echo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/echo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/echo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10273\", \"unit_name\": \"echo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/echo"
+          },
+          "test_migration_wp__labs__ecol": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ecol",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ecol\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ecol\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ecol\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"11221\", \"unit_name\": \"ecol\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ecol"
+          },
+          "test_migration_wp__labs__ecotox": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ecotox",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ecotox\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ecotox\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ecotox\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10203\", \"unit_name\": \"enac-do\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ecotox"
+          },
+          "test_migration_wp__labs__ecps": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ecps",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ecps\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ecps\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ecps\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12653\", \"unit_name\": \"ecps\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ecps"
+          },
+          "test_migration_wp__labs__edlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/edlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/edlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/edlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/edlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12664\", \"unit_name\": \"gr-sci-iel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/edlab"
+          },
+          "test_migration_wp__labs__eelab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/eelab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/eelab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/eelab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/eelab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11011\", \"unit_name\": \"smx-ens\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/eelab"
+          },
+          "test_migration_wp__labs__eesd": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/eesd",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/eesd\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/eesd\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/eesd\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"de\", \"fr\"], \"unit_id\": \"12170\", \"unit_name\": \"eesd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/eesd"
+          },
+          "test_migration_wp__labs__elab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/elab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/elab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/elab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/elab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11978\", \"unit_name\": \"gr-ka\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/elab"
+          },
+          "test_migration_wp__labs__emc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/emc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/emc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/emc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/emc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12147\", \"unit_name\": \"sci-sti-fr\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/emc"
+          },
+          "test_migration_wp__labs__eml": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/eml",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/eml\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/eml\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/eml\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11256\", \"unit_name\": \"eml\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/eml"
+          },
+          "test_migration_wp__labs__emplus": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/emplus",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/emplus\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/emplus\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/emplus\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13477\", \"unit_name\": \"emplus\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/emplus"
+          },
+          "test_migration_wp__labs__emsi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/emsi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/emsi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/emsi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/emsi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13346\", \"unit_name\": \"emsi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/emsi"
+          },
+          "test_migration_wp__labs__enac_am": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/enac-am",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/enac-am\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/enac-am\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/enac-am\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"17\", \"unit_name\": \"enac-am\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/enac-am"
+          },
+          "test_migration_wp__labs__enacit2": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/enacit2",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/enacit2\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/enacit2\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/enacit2\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10208\", \"unit_name\": \"enac-it\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/enacit2"
+          },
+          "test_migration_wp__labs__entc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/entc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/entc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/entc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/entc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11255\", \"unit_name\": \"entc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/entc"
+          },
+          "test_migration_wp__labs__epsl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/epsl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/epsl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/epsl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/epsl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12330\", \"unit_name\": \"epsl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/epsl"
+          },
+          "test_migration_wp__labs__esl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/esl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/esl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/esl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/esl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11977\", \"unit_name\": \"esl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/esl"
+          },
+          "test_migration_wp__labs__expertise": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/expertise",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/expertise\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/expertise\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/expertise\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10252\", \"unit_name\": \"leure\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/expertise"
+          },
+          "test_migration_wp__labs__fellay_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/fellay-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/fellay-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/fellay-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/fellay-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12477\", \"unit_name\": \"gr-fe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/fellay-lab"
+          },
+          "test_migration_wp__labs__ffo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ffo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ffo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ffo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ffo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13276\", \"unit_name\": \"sci-sti-dd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ffo"
+          },
+          "test_migration_wp__labs__fimap": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/fimap",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/fimap\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/fimap\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/fimap\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12702\", \"unit_name\": \"fimap\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/fimap"
+          },
+          "test_migration_wp__labs__flexlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/flexlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/flexlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/flexlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/flexlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13471\", \"unit_name\": \"flexlab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/flexlab"
+          },
+          "test_migration_wp__labs__form": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/form",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/form\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/form\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/form\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12812\", \"unit_name\": \"form\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/form"
+          },
+          "test_migration_wp__labs__fsl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/fsl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/fsl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/fsl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/fsl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13203\", \"unit_name\": \"fsl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/fsl"
+          },
+          "test_migration_wp__labs__galatea": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/galatea",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/galatea\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/galatea\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/galatea\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13016\", \"unit_name\": \"galatea\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/galatea"
+          },
+          "test_migration_wp__labs__gel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gel\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13064\", \"unit_name\": \"gel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gel"
+          },
+          "test_migration_wp__labs__gem": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gem",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gem\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gem\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gem\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12692\", \"unit_name\": \"sci-sti-jvh\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gem"
+          },
+          "test_migration_wp__labs__gemini_e3": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gemini-e3",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gemini-e3\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gemini-e3\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gemini-e3\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10252\", \"unit_name\": \"leure\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gemini-e3"
+          },
+          "test_migration_wp__labs__genomic_resources": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/genomic-resources",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/genomic-resources\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/genomic-resources\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/genomic-resources\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10244\", \"unit_name\": \"lasig\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/genomic-resources"
+          },
+          "test_migration_wp__labs__gfo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gfo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gfo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gfo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gfo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12146\", \"unit_name\": \"sci-sti-lt\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gfo"
+          },
+          "test_migration_wp__labs__gis": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gis",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gis\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gis\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gis\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12118\", \"unit_name\": \"gis-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gis"
+          },
+          "test_migration_wp__labs__gonczy_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gonczy-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gonczy-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gonczy-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gonczy-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11155\", \"unit_name\": \"upgon\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gonczy-lab"
+          },
+          "test_migration_wp__labs__gr_cel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gr-cel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gr-cel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gr-cel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gr-cel\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11838\", \"unit_name\": \"gr-cel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gr-cel"
+          },
+          "test_migration_wp__labs__gr_tes": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gr-tes",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gr-tes\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gr-tes\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gr-tes\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11822\", \"unit_name\": \"egg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gr-tes"
+          },
+          "test_migration_wp__labs__graefflab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/graefflab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/graefflab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/graefflab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/graefflab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12824\", \"unit_name\": \"upgraeff\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/graefflab"
+          },
+          "test_migration_wp__labs__gramm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/gramm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/gramm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/gramm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/gramm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12149\", \"unit_name\": \"sci-sti-mm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/gramm"
+          },
+          "test_migration_wp__labs__grpi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/grpi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/grpi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/grpi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/grpi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12392\", \"unit_name\": \"gr-pi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/grpi"
+          },
+          "test_migration_wp__labs__habitat": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/habitat",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/habitat\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/habitat\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/habitat\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12780\", \"unit_name\": \"lab-u\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/habitat"
+          },
+          "test_migration_wp__labs__hanahan_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/hanahan-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/hanahan-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/hanahan-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/hanahan-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12095\", \"unit_name\": \"cmso\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/hanahan-lab"
+          },
+          "test_migration_wp__labs__herus": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/herus",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/herus\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/herus\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/herus\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13132\", \"unit_name\": \"herus\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/herus"
+          },
+          "test_migration_wp__labs__hessbellwald_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/hessbellwald-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/hessbellwald-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/hessbellwald-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/hessbellwald-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13046\", \"unit_name\": \"uphess\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/hessbellwald-lab"
+          },
+          "test_migration_wp__labs__het": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/het",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/het\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/het\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/het\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11425\", \"unit_name\": \"lptp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/het"
+          },
+          "test_migration_wp__labs__hl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/hl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/hl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/hl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/hl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12587\", \"unit_name\": \"sci-sti-hl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/hl"
+          },
+          "test_migration_wp__labs__hobel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/hobel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/hobel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/hobel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/hobel\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13578\", \"unit_name\": \"hobel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/hobel"
+          },
+          "test_migration_wp__labs__huelsken_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/huelsken-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/huelsken-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/huelsken-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/huelsken-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11259\", \"unit_name\": \"uphuelsken\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/huelsken-lab"
+          },
+          "test_migration_wp__labs__hummel_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/hummel-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/hummel-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/hummel-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/hummel-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13320\", \"unit_name\": \"uphummel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/hummel-lab"
+          },
+          "test_migration_wp__labs__iahr2020": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/iahr2020",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/iahr2020\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/iahr2020\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/iahr2020\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"10309\", \"unit_name\": \"lmh\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/iahr2020"
+          },
+          "test_migration_wp__labs__ibois": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ibois",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ibois\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ibois\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ibois\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10236\", \"unit_name\": \"ibois\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ibois"
+          },
+          "test_migration_wp__labs__iclab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/iclab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/iclab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/iclab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/iclab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12701\", \"unit_name\": \"iclab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/iclab"
+          },
+          "test_migration_wp__labs__icnf2019": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/icnf2019",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/icnf2019\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/icnf2019\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/icnf2019\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"12701\", \"unit_name\": \"iclab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/icnf2019"
+          },
+          "test_migration_wp__labs__ict4sm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ict4sm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ict4sm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ict4sm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ict4sm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13059\", \"unit_name\": \"sci-sti-dk\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ict4sm"
+          },
+          "test_migration_wp__labs__ideas": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ideas",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ideas\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ideas\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ideas\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12329\", \"unit_name\": \"last\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ideas"
+          },
+          "test_migration_wp__labs__idiap": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/idiap",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/idiap\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/idiap\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/idiap\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10381\", \"unit_name\": \"lidiap\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/idiap"
+          },
+          "test_migration_wp__labs__iig": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/iig",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/iig\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/iig\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/iig\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12345\", \"unit_name\": \"sci-ic-rb\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/iig"
+          },
+          "test_migration_wp__labs__imac": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/imac",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/imac\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/imac\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/imac\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10237\", \"unit_name\": \"imac\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/imac"
+          },
+          "test_migration_wp__labs__innoseed_enac": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/innoseed-enac",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/innoseed-enac\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/innoseed-enac\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/innoseed-enac\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13324\", \"unit_name\": \"enac-inno\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/innoseed-enac"
+          },
+          "test_migration_wp__labs__instantlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/instantlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/instantlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/instantlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/instantlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12651\", \"unit_name\": \"instant-lab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/instantlab"
+          },
+          "test_migration_wp__labs__ipese": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ipese",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ipese\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ipese\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ipese\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12691\", \"unit_name\": \"sci-sti-fm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ipese"
+          },
+          "test_migration_wp__labs__iphys_it": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/iphys-it",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/iphys-it\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/iphys-it\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/iphys-it\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13150\", \"unit_name\": \"iphys-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/iphys-it"
+          },
+          "test_migration_wp__labs__isic": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/isic",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/isic\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/isic\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/isic\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10095\", \"unit_name\": \"isic\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/isic"
+          },
+          "test_migration_wp__labs__ivrl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ivrl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ivrl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ivrl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ivrl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10429\", \"unit_name\": \"ivrl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ivrl"
+          },
+          "test_migration_wp__labs__k_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/k-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/k-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/k-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/k-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11892\", \"unit_name\": \"lpqm1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/k-lab"
+          },
+          "test_migration_wp__labs__la": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/la",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/la\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/la\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/la\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12397\", \"unit_name\": \"la3\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/la"
+          },
+          "test_migration_wp__labs__lab_u": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lab-u",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lab-u\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lab-u\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lab-u\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12780\", \"unit_name\": \"lab-u\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lab-u"
+          },
+          "test_migration_wp__labs__laba": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/laba",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/laba\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/laba\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/laba\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11188\", \"unit_name\": \"laba\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/laba"
+          },
+          "test_migration_wp__labs__labos": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/labos",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/labos\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/labos\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/labos\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10700\", \"unit_name\": \"labos\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/labos"
+          },
+          "test_migration_wp__labs__lacal": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lacal",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lacal\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lacal\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lacal\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11265\", \"unit_name\": \"lacal\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lacal"
+          },
+          "test_migration_wp__labs__lai": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lai",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lai\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lai\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lai\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10351\", \"unit_name\": \"lai\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lai"
+          },
+          "test_migration_wp__labs__lammm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lammm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lammm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lammm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lammm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12614\", \"unit_name\": \"lammm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lammm"
+          },
+          "test_migration_wp__labs__lamp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lamp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lamp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lamp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lamp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10409\", \"unit_name\": \"lamp1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lamp"
+          },
+          "test_migration_wp__labs__lams_next": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lams-next",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lams-next\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lams-next\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lams-next\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10412\", \"unit_name\": \"lams\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lams-next"
+          },
+          "test_migration_wp__labs__lanes": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lanes",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lanes\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lanes\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lanes\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11840\", \"unit_name\": \"lanes\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lanes"
+          },
+          "test_migration_wp__labs__lap": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lap",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lap\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lap\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lap\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10418\", \"unit_name\": \"lap\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lap"
+          },
+          "test_migration_wp__labs__lapd": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lapd",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lapd\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lapd\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lapd\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12209\", \"unit_name\": \"lapd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lapd"
+          },
+          "test_migration_wp__labs__lapi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lapi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lapi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lapi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lapi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13601\", \"unit_name\": \"lapi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lapi"
+          },
+          "test_migration_wp__labs__lapis": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lapis",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lapis\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lapis\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lapis\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12759\", \"unit_name\": \"lapis\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lapis"
+          },
+          "test_migration_wp__labs__lasa": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lasa",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lasa\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lasa\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lasa\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10660\", \"unit_name\": \"lasa\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lasa"
+          },
+          "test_migration_wp__labs__lashuel_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lashuel-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lashuel-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lashuel-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lashuel-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11104\", \"unit_name\": \"lmnn\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lashuel-lab"
+          },
+          "test_migration_wp__labs__lasig": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lasig",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lasig\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lasig\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lasig\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10244\", \"unit_name\": \"lasig\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lasig"
+          },
+          "test_migration_wp__labs__laspe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/laspe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/laspe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/laspe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/laspe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10946\", \"unit_name\": \"laspe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/laspe"
+          },
+          "test_migration_wp__labs__last": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/last",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/last\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/last\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/last\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12329\", \"unit_name\": \"last\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/last"
+          },
+          "test_migration_wp__labs__lastro": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lastro",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lastro\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lastro\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lastro\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10933\", \"unit_name\": \"lastro\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lastro"
+          },
+          "test_migration_wp__labs__lasur": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lasur",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lasur\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lasur\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lasur\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10241\", \"unit_name\": \"lasur\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lasur"
+          },
+          "test_migration_wp__labs__lbe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lbe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lbe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lbe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lbe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10268\", \"unit_name\": \"lbe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lbe"
+          },
+          "test_migration_wp__labs__lbm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lbm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lbm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lbm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lbm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11830\", \"unit_name\": \"updalpe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lbm"
+          },
+          "test_migration_wp__labs__lbni": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lbni",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lbni\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lbni\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lbni\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12183\", \"unit_name\": \"lbni\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lbni"
+          },
+          "test_migration_wp__labs__lbo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lbo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lbo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lbo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lbo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10299\", \"unit_name\": \"lbo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lbo"
+          },
+          "test_migration_wp__labs__lbp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lbp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lbp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lbp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lbp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12398\", \"unit_name\": \"lbp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lbp"
+          },
+          "test_migration_wp__labs__lbs": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lbs",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lbs\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lbs\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lbs\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10871\", \"unit_name\": \"lbs\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lbs"
+          },
+          "test_migration_wp__labs__lcav": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lcav",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lcav\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lcav\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lcav\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10434\", \"unit_name\": \"lcav\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lcav"
+          },
+          "test_migration_wp__labs__lcc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lcc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lcc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lcc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lcc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10226\", \"unit_name\": \"lcc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lcc"
+          },
+          "test_migration_wp__labs__lce": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lce",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lce\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lce\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lce\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11718\", \"unit_name\": \"lce\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lce"
+          },
+          "test_migration_wp__labs__lch": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lch",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lch\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lch\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lch\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"de\", \"fr\"], \"unit_id\": \"10263\", \"unit_name\": \"pl-lch\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lch"
+          },
+          "test_migration_wp__labs__lcn": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lcn",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lcn\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lcn\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lcn\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10416\", \"unit_name\": \"lcn1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lcn"
+          },
+          "test_migration_wp__labs__lcpm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lcpm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lcpm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lcpm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lcpm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10106\", \"unit_name\": \"lcpm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lcpm"
+          },
+          "test_migration_wp__labs__lcvmm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lcvmm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lcvmm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lcvmm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lcvmm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10163\", \"unit_name\": \"lcvmm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lcvmm"
+          },
+          "test_migration_wp__labs__ldm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ldm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ldm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ldm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ldm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"11268\", \"unit_name\": \"ldm1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ldm"
+          },
+          "test_migration_wp__labs__leago": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/leago",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/leago\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/leago\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/leago\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13603\", \"unit_name\": \"leago\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/leago"
+          },
+          "test_migration_wp__labs__leb": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/leb",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/leb\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/leb\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/leb\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12031\", \"unit_name\": \"leb\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/leb"
+          },
+          "test_migration_wp__labs__lemaitrelab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lemaitrelab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lemaitrelab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lemaitrelab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lemaitrelab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11772\", \"unit_name\": \"uplem\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lemaitrelab"
+          },
+          "test_migration_wp__labs__lemr": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lemr",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lemr\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lemr\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lemr\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13063\", \"unit_name\": \"lemr\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lemr"
+          },
+          "test_migration_wp__labs__len": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/len",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/len\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/len\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/len\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10457\", \"unit_name\": \"len\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/len"
+          },
+          "test_migration_wp__labs__leso": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/leso",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/leso\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/leso\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/leso\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10262\", \"unit_name\": \"leso-pb\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/leso"
+          },
+          "test_migration_wp__labs__leure": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/leure",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/leure\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/leure\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/leure\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10252\", \"unit_name\": \"leure\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/leure"
+          },
+          "test_migration_wp__labs__lfmi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lfmi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lfmi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lfmi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lfmi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12052\", \"unit_name\": \"lfmi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lfmi"
+          },
+          "test_migration_wp__labs__lgb": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lgb",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lgb\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lgb\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lgb\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12552\", \"unit_name\": \"lgb\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lgb"
+          },
+          "test_migration_wp__labs__lhtc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lhtc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lhtc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lhtc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lhtc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11843\", \"unit_name\": \"lhtc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lhtc"
+          },
+          "test_migration_wp__labs__lifmet": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lifmet",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lifmet\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lifmet\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lifmet\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10984\", \"unit_name\": \"lifmet\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lifmet"
+          },
+          "test_migration_wp__labs__lingner_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lingner-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lingner-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lingner-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lingner-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11159\", \"unit_name\": \"uplin\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lingner-lab"
+          },
+          "test_migration_wp__labs__linx": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/linx",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/linx\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/linx\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/linx\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12434\", \"unit_name\": \"linx\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/linx"
+          },
+          "test_migration_wp__labs__lions": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lions",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lions\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lions\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lions\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12179\", \"unit_name\": \"lions\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lions"
+          },
+          "test_migration_wp__labs__lipid": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lipid",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lipid\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lipid\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lipid\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12325\", \"unit_name\": \"lipid\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lipid"
+          },
+          "test_migration_wp__labs__lis": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lis",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lis\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lis\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lis\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10370\", \"unit_name\": \"lis\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lis"
+          },
+          "test_migration_wp__labs__lmaf": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmaf",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmaf\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmaf\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmaf\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10367\", \"unit_name\": \"lmaf\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmaf"
+          },
+          "test_migration_wp__labs__lmam": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmam",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmam\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmam\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmam\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10303\", \"unit_name\": \"lmam\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmam"
+          },
+          "test_migration_wp__labs__lmc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10341\", \"unit_name\": \"lmc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmc"
+          },
+          "test_migration_wp__labs__lmgn": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmgn",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmgn\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmgn\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmgn\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13021\", \"unit_name\": \"lmgn\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmgn"
+          },
+          "test_migration_wp__labs__lmh": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmh",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmh\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmh\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmh\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10309\", \"unit_name\": \"lmh\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmh"
+          },
+          "test_migration_wp__labs__lmis1": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmis1",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmis1\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmis1\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmis1\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10321\", \"unit_name\": \"lmis1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmis1"
+          },
+          "test_migration_wp__labs__lmis2": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmis2",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmis2\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmis2\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmis2\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10322\", \"unit_name\": \"lmis2\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmis2"
+          },
+          "test_migration_wp__labs__lmis4": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmis4",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmis4\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmis4\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmis4\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10324\", \"unit_name\": \"lmis4\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmis4"
+          },
+          "test_migration_wp__labs__lmm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10336\", \"unit_name\": \"lmm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmm"
+          },
+          "test_migration_wp__labs__lmom": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmom",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmom\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmom\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmom\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12015\", \"unit_name\": \"lmom\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmom"
+          },
+          "test_migration_wp__labs__lms": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lms",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lms\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lms\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lms\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10264\", \"unit_name\": \"lms\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lms"
+          },
+          "test_migration_wp__labs__lmsc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmsc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmsc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmsc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmsc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11832\", \"unit_name\": \"lmsc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmsc"
+          },
+          "test_migration_wp__labs__lmtm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmtm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmtm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmtm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmtm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12903\", \"unit_name\": \"lmtm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmtm"
+          },
+          "test_migration_wp__labs__lmts": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lmts",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lmts\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lmts\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lmts\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10955\", \"unit_name\": \"lmts\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lmts"
+          },
+          "test_migration_wp__labs__lnb": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lnb",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lnb\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lnb\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lnb\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12909\", \"unit_name\": \"lnb\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lnb"
+          },
+          "test_migration_wp__labs__lnce": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lnce",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lnce\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lnce\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lnce\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13077\", \"unit_name\": \"lnce\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lnce"
+          },
+          "test_migration_wp__labs__lnco": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lnco",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lnco\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lnco\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lnco\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11025\", \"unit_name\": \"lnco\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lnco"
+          },
+          "test_migration_wp__labs__lnd": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lnd",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lnd\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lnd\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lnd\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13266\", \"unit_name\": \"lnd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lnd"
+          },
+          "test_migration_wp__labs__lne": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lne",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lne\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lne\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lne\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13047\", \"unit_name\": \"lne\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lne"
+          },
+          "test_migration_wp__labs__lns": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lns",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lns\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lns\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lns\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10150\", \"unit_name\": \"lns\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lns"
+          },
+          "test_migration_wp__labs__lo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11723\", \"unit_name\": \"lo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lo"
+          },
+          "test_migration_wp__labs__lp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10342\", \"unit_name\": \"lp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lp"
+          },
+          "test_migration_wp__labs__lpac": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpac",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpac\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpac\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpac\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13295\", \"unit_name\": \"lpac\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpac"
+          },
+          "test_migration_wp__labs__lpap": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpap",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpap\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpap\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpap\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10658\", \"unit_name\": \"lpap\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpap"
+          },
+          "test_migration_wp__labs__lpbs": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpbs",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpbs\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpbs\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpbs\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13565\", \"unit_name\": \"lpbs\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpbs"
+          },
+          "test_migration_wp__labs__lpdi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpdi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpdi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpdi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpdi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13000\", \"unit_name\": \"lpdi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpdi"
+          },
+          "test_migration_wp__labs__lphe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lphe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lphe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lphe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lphe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"10863\", \"unit_name\": \"lphe1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lphe"
+          },
+          "test_migration_wp__labs__lpi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10101\", \"unit_name\": \"lpi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpi"
+          },
+          "test_migration_wp__labs__lpmat": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpmat",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpmat\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpmat\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpmat\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12141\", \"unit_name\": \"lpmat\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpmat"
+          },
+          "test_migration_wp__labs__lpmc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpmc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpmc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpmc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpmc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10142\", \"unit_name\": \"lpmc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpmc"
+          },
+          "test_migration_wp__labs__lpmn": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpmn",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpmn\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpmn\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpmn\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10149\", \"unit_name\": \"lpmn\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpmn"
+          },
+          "test_migration_wp__labs__lpmv": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpmv",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpmv\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpmv\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpmv\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10868\", \"unit_name\": \"lpmv\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpmv"
+          },
+          "test_migration_wp__labs__lpn": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lpn",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lpn\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lpn\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lpn\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10158\", \"unit_name\": \"lpn\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lpn"
+          },
+          "test_migration_wp__labs__lppc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lppc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lppc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lppc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lppc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10869\", \"unit_name\": \"lppc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lppc"
+          },
+          "test_migration_wp__labs__lppt": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lppt",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lppt\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lppt\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lppt\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11959\", \"unit_name\": \"lppt\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lppt"
+          },
+          "test_migration_wp__labs__lptp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lptp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lptp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lptp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lptp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11425\", \"unit_name\": \"lptp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lptp"
+          },
+          "test_migration_wp__labs__lqg": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lqg",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lqg\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lqg\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lqg\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13289\", \"unit_name\": \"lqg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lqg"
+          },
+          "test_migration_wp__labs__lqm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lqm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lqm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lqm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lqm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11706\", \"unit_name\": \"lqm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lqm"
+          },
+          "test_migration_wp__labs__lqno": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lqno",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lqno\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lqno\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lqno\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13462\", \"unit_name\": \"gr-ga\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lqno"
+          },
+          "test_migration_wp__labs__lrese": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lrese",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lrese\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lrese\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lrese\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12656\", \"unit_name\": \"lrese\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lrese"
+          },
+          "test_migration_wp__labs__lrm": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lrm",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lrm\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lrm\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lrm\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12975\", \"unit_name\": \"lrm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lrm"
+          },
+          "test_migration_wp__labs__lrs": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lrs",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lrs\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lrs\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lrs\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12619\", \"unit_name\": \"lrs\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lrs"
+          },
+          "test_migration_wp__labs__lsbi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsbi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsbi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsbi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsbi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12393\", \"unit_name\": \"lsbi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsbi"
+          },
+          "test_migration_wp__labs__lse": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lse",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lse\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lse\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lse\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13463\", \"unit_name\": \"sci-sb-mg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lse"
+          },
+          "test_migration_wp__labs__lsen": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsen",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsen\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsen\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsen\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10152\", \"unit_name\": \"lsen\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsen"
+          },
+          "test_migration_wp__labs__lsi": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsi",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsi\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsi\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsi\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11140\", \"unit_name\": \"lsi1\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsi"
+          },
+          "test_migration_wp__labs__lsir": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsir",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsir\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsir\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsir\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10405\", \"unit_name\": \"lsir\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsir"
+          },
+          "test_migration_wp__labs__lsis": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsis",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsis\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsis\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsis\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10452\", \"unit_name\": \"sv-it\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsis"
+          },
+          "test_migration_wp__labs__lsme": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsme",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsme\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsme\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsme\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11814\", \"unit_name\": \"lsme\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsme"
+          },
+          "test_migration_wp__labs__lsms": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsms",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsms\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsms\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsms\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10232\", \"unit_name\": \"lsms\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsms"
+          },
+          "test_migration_wp__labs__lsp": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsp",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsp\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsp\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsp\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11900\", \"unit_name\": \"ph-ic\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsp"
+          },
+          "test_migration_wp__labs__lsym": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lsym",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lsym\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lsym\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lsym\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11233\", \"unit_name\": \"lsym\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lsym"
+          },
+          "test_migration_wp__labs__lte": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lte",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lte\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lte\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lte\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11534\", \"unit_name\": \"lte\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lte"
+          },
+          "test_migration_wp__labs__lth3": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lth3",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lth3\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lth3\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lth3\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10228\", \"unit_name\": \"lth3\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lth3"
+          },
+          "test_migration_wp__labs__ltqe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ltqe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ltqe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ltqe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ltqe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12400\", \"unit_name\": \"ltqe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ltqe"
+          },
+          "test_migration_wp__labs__lts4": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lts4",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lts4\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lts4\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lts4\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10851\", \"unit_name\": \"lts4\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lts4"
+          },
+          "test_migration_wp__labs__lts5www": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lts5www",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lts5www\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lts5www\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lts5www\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10954\", \"unit_name\": \"lts5\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lts5www"
+          },
+          "test_migration_wp__labs__lumes": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lumes",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lumes\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lumes\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lumes\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12311\", \"unit_name\": \"lumes\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lumes"
+          },
+          "test_migration_wp__labs__luts": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/luts",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/luts\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/luts\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/luts\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12124\", \"unit_name\": \"luts\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/luts"
+          },
+          "test_migration_wp__labs__lwe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/lwe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/lwe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/lwe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/lwe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13119\", \"unit_name\": \"lwe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/lwe"
+          },
+          "test_migration_wp__labs__mag": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mag",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mag\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mag\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mag\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13307\", \"unit_name\": \"sci-sti-as\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mag"
+          },
+          "test_migration_wp__labs__manslab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/manslab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/manslab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/manslab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/manslab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"12761\", \"unit_name\": \"manslab-co\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/manslab"
+          },
+          "test_migration_wp__labs__markram_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/markram-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/markram-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/markram-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/markram-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10458\", \"unit_name\": \"lnmc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/markram-lab"
+          },
+          "test_migration_wp__labs__master_architecture": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/master-architecture",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/master-architecture\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/master-architecture\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/master-architecture\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10564\", \"unit_name\": \"sar-d\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/master-architecture"
+          },
+          "test_migration_wp__labs__mccabelab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mccabelab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mccabelab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mccabelab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mccabelab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13082\", \"unit_name\": \"upmccabe\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mccabelab"
+          },
+          "test_migration_wp__labs__mckinney_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mckinney-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mckinney-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mckinney-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mckinney-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11741\", \"unit_name\": \"upkin\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mckinney-lab"
+          },
+          "test_migration_wp__labs__mcs": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mcs",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mcs\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mcs\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mcs\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10231\", \"unit_name\": \"mcs\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mcs"
+          },
+          "test_migration_wp__labs__mechanical_spectroscopy": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mechanical-spectroscopy",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mechanical-spectroscopy\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mechanical-spectroscopy\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mechanical-spectroscopy\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10142\", \"unit_name\": \"lpmc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mechanical-spectroscopy"
+          },
+          "test_migration_wp__labs__meylan_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/meylan-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/meylan-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/meylan-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/meylan-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12436\", \"unit_name\": \"upmeylan\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/meylan-lab"
+          },
+          "test_migration_wp__labs__mhmc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mhmc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mhmc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mhmc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mhmc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10342\", \"unit_name\": \"lp\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mhmc"
+          },
+          "test_migration_wp__labs__microbs": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/microbs",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/microbs\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/microbs\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/microbs\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13117\", \"unit_name\": \"microbs\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/microbs"
+          },
+          "test_migration_wp__labs__mir": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mir",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mir\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mir\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mir\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12065\", \"unit_name\": \"mir\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mir"
+          },
+          "test_migration_wp__labs__mlo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mlo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mlo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mlo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mlo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13319\", \"unit_name\": \"mlo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mlo"
+          },
+          "test_migration_wp__labs__mmspg": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mmspg",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mmspg\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mmspg\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mmspg\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11889\", \"unit_name\": \"gr-eb\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mmspg"
+          },
+          "test_migration_wp__labs__mns": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/mns",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/mns\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/mns\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/mns\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13308\", \"unit_name\": \"mns\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/mns"
+          },
+          "test_migration_wp__labs__naef_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/naef-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/naef-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/naef-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/naef-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11260\", \"unit_name\": \"upnae\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/naef-lab"
+          },
+          "test_migration_wp__labs__nal": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nal",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nal\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nal\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nal\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12550\", \"unit_name\": \"nal\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nal"
+          },
+          "test_migration_wp__labs__nanolab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nanolab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nanolab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nanolab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nanolab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10328\", \"unit_name\": \"nanolab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nanolab"
+          },
+          "test_migration_wp__labs__naveiras_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/naveiras-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/naveiras-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/naveiras-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/naveiras-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12818\", \"unit_name\": \"gr-naveiras\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/naveiras-lab"
+          },
+          "test_migration_wp__labs__nems": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nems",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nems\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nems\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nems\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12739\", \"unit_name\": \"nems\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nems"
+          },
+          "test_migration_wp__labs__nextgen": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nextgen",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nextgen\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nextgen\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nextgen\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10244\", \"unit_name\": \"lasig\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nextgen"
+          },
+          "test_migration_wp__labs__nm2": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nm2",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nm2\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nm2\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nm2\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"11230\", \"unit_name\": \"bbp-core\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nm2"
+          },
+          "test_migration_wp__labs__nolossproject": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nolossproject",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nolossproject\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nolossproject\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nolossproject\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"10373\", \"unit_name\": \"nam\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nolossproject"
+          },
+          "test_migration_wp__labs__nsbl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/nsbl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/nsbl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/nsbl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/nsbl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13622\", \"unit_name\": \"gr-laman\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/nsbl"
+          },
+          "test_migration_wp__labs__ntcm2018": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ntcm2018",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ntcm2018\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ntcm2018\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ntcm2018\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"13021\", \"unit_name\": \"lmgn\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ntcm2018"
+          },
+          "test_migration_wp__labs__oateslab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/oateslab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/oateslab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/oateslab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/oateslab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13325\", \"unit_name\": \"upoates\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/oateslab"
+          },
+          "test_migration_wp__labs__pbl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/pbl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/pbl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/pbl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/pbl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13293\", \"unit_name\": \"pbl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/pbl"
+          },
+          "test_migration_wp__labs__pcsl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/pcsl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/pcsl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/pcsl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/pcsl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13087\", \"unit_name\": \"pcsl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/pcsl"
+          },
+          "test_migration_wp__labs__pde": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/pde",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/pde\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/pde\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/pde\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12235\", \"unit_name\": \"pde\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/pde"
+          },
+          "test_migration_wp__labs__pel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/pel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/pel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/pel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/pel\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12902\", \"unit_name\": \"pel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/pel"
+          },
+          "test_migration_wp__labs__persat_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/persat-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/persat-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/persat-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/persat-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13303\", \"unit_name\": \"uppersat\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/persat-lab"
+          },
+          "test_migration_wp__labs__phosl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/phosl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/phosl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/phosl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/phosl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12394\", \"unit_name\": \"phosl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/phosl"
+          },
+          "test_migration_wp__labs__pixe": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/pixe",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/pixe\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/pixe\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/pixe\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10230\", \"unit_name\": \"iic-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/pixe"
+          },
+          "test_migration_wp__labs__plte": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/plte",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/plte\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/plte\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/plte\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"13355\", \"unit_name\": \"enac-plte\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/plte"
+          },
+          "test_migration_wp__labs__powerlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/powerlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/powerlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/powerlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/powerlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13020\", \"unit_name\": \"powerlab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/powerlab"
+          },
+          "test_migration_wp__labs__prob": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/prob",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/prob\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/prob\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/prob\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10123\", \"unit_name\": \"prob\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/prob"
+          },
+          "test_migration_wp__labs__prst": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/prst",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/prst\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/prst\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/prst\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"10128\", \"unit_name\": \"prst\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/prst"
+          },
+          "test_migration_wp__labs__ptbtg": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ptbtg",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ptbtg\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ptbtg\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ptbtg\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13474\", \"unit_name\": \"ptbtg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ptbtg"
+          },
+          "test_migration_wp__labs__pvlab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/pvlab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/pvlab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/pvlab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/pvlab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11963\", \"unit_name\": \"pv-lab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/pvlab"
+          },
+          "test_migration_wp__labs__q_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/q-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/q-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/q-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/q-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13060\", \"unit_name\": \"gr-qua\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/q-lab"
+          },
+          "test_migration_wp__labs__radtke_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/radtke-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/radtke-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/radtke-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/radtke-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11429\", \"unit_name\": \"uprad\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/radtke-lab"
+          },
+          "test_migration_wp__labs__ramdya_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ramdya-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ramdya-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ramdya-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ramdya-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13360\", \"unit_name\": \"upramdya\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ramdya-lab"
+          },
+          "test_migration_wp__labs__rao": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/rao",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/rao\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/rao\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/rao\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12788\", \"unit_name\": \"rao\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/rao"
+          },
+          "test_migration_wp__labs__react": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/react",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/react\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/react\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/react\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12390\", \"unit_name\": \"sci-sti-dg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/react"
+          },
+          "test_migration_wp__labs__resslab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/resslab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/resslab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/resslab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/resslab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10233\", \"unit_name\": \"resslab\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/resslab"
+          },
+          "test_migration_wp__labs__rfic": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/rfic",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/rfic\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/rfic\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/rfic\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12148\", \"unit_name\": \"sci-sti-cd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/rfic"
+          },
+          "test_migration_wp__labs__rrl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/rrl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/rrl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/rrl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/rrl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12520\", \"unit_name\": \"rrl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/rrl"
+          },
+          "test_migration_wp__labs__sber": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/sber",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/sber\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/sber\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/sber\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13006\", \"unit_name\": \"sber\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/sber"
+          },
+          "test_migration_wp__labs__scaffolds2018": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/scaffolds2018",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/scaffolds2018\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/scaffolds2018\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/scaffolds2018\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"11533\", \"unit_name\": \"alice\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/scaffolds2018"
+          },
+          "test_migration_wp__labs__schoonjans_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/schoonjans-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/schoonjans-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/schoonjans-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/schoonjans-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12735\", \"unit_name\": \"upschoonjans\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/schoonjans-lab"
+          },
+          "test_migration_wp__labs__sci_sb_rh": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/sci-sb-rh",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/sci-sb-rh\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/sci-sb-rh\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/sci-sb-rh\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"13466\", \"unit_name\": \"sci-sb-rh\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/sci-sb-rh"
+          },
+          "test_migration_wp__labs__servicedesk_sandbox": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/servicedesk-sandbox",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/servicedesk-sandbox\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/servicedesk-sandbox\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/servicedesk-sandbox\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13034\", \"unit_name\": \"exdesk\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/servicedesk-sandbox"
+          },
+          "test_migration_wp__labs__simanis_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/simanis-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/simanis-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/simanis-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/simanis-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11430\", \"unit_name\": \"upsim\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/simanis-lab"
+          },
+          "test_migration_wp__labs__skil": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/skil",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/skil\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/skil\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/skil\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"10203\", \"unit_name\": \"enac-do\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/skil"
+          },
+          "test_migration_wp__labs__smal": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/smal",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/smal\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/smal\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/smal\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12820\", \"unit_name\": \"smal\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/smal"
+          },
+          "test_migration_wp__labs__smat": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/smat",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/smat\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/smat\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/smat\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11798\", \"unit_name\": \"smat\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/smat"
+          },
+          "test_migration_wp__labs__sois": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/sois",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/sois\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/sois\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/sois\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12770\", \"unit_name\": \"gr-dil\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/sois"
+          },
+          "test_migration_wp__labs__spc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/spc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/spc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/spc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/spc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12266\", \"unit_name\": \"spc-ge\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/spc"
+          },
+          "test_migration_wp__labs__spring": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/spring",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/spring\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/spring\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/spring\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13548\", \"unit_name\": \"spring\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/spring"
+          },
+          "test_migration_wp__labs__sps": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/sps",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/sps\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/sps\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/sps\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"13022\", \"unit_name\": \"sps\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/sps"
+          },
+          "test_migration_wp__labs__stap": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/stap",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/stap\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/stap\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/stap\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10127\", \"unit_name\": \"stap\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/stap"
+          },
+          "test_migration_wp__labs__stat": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/stat",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/stat\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/stat\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/stat\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10124\", \"unit_name\": \"stat\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/stat"
+          },
+          "test_migration_wp__labs__sunmil": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/sunmil",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/sunmil\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/sunmil\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/sunmil\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12173\", \"unit_name\": \"sunmil\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/sunmil"
+          },
+          "test_migration_wp__labs__sxl2": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/sxl2",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/sxl2\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/sxl2\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/sxl2\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13216\", \"unit_name\": \"sxl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/sxl2"
+          },
+          "test_migration_wp__labs__tan": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tan",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tan\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tan\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tan\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"11828\", \"unit_name\": \"tan\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tan"
+          },
+          "test_migration_wp__labs__tang_lab": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tang-lab",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tang-lab\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tang-lab\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tang-lab\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13294\", \"unit_name\": \"lbi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tang-lab"
+          },
+          "test_migration_wp__labs__tcl": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tcl",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tcl\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tcl\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tcl\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12395\", \"unit_name\": \"tcl\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tcl"
+          },
+          "test_migration_wp__labs__tebel": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tebel",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tebel\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tebel\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tebel\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13545\", \"unit_name\": \"tebel\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tebel"
+          },
+          "test_migration_wp__labs__test_medias": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/test-medias",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/test-medias\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/test-medias\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/test-medias\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12495\", \"unit_name\": \"csqi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/test-medias"
+          },
+          "test_migration_wp__labs__test_polylex": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/test-polylex",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/test-polylex\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/test-polylex\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/test-polylex\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12495\", \"unit_name\": \"csqi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/test-polylex"
+          },
+          "test_migration_wp__labs__test_slug": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/test-slug",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/test-slug\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/test-slug\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/test-slug\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12495\", \"unit_name\": \"csqi\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/test-slug"
+          },
+          "test_migration_wp__labs__theos": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/theos",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/theos\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/theos\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/theos\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12411\", \"unit_name\": \"theos\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/theos"
+          },
+          "test_migration_wp__labs__tic": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tic",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tic\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tic\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tic\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12151\", \"unit_name\": \"sci-sti-sm\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tic"
+          },
+          "test_migration_wp__labs__topo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/topo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/topo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/topo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/topo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"10249\", \"unit_name\": \"topo\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/topo"
+          },
+          "test_migration_wp__labs__tox": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tox",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tox\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tox\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tox\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12482\", \"unit_name\": \"tox\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tox"
+          },
+          "test_migration_wp__labs__tsam": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/tsam",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/tsam\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/tsam\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/tsam\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"11768\", \"unit_name\": \"tsam\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/tsam"
+          },
+          "test_migration_wp__labs__unfold": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/unfold",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/unfold\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/unfold\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/unfold\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13018\", \"unit_name\": \"unfold\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/unfold"
+          },
+          "test_migration_wp__labs__urbangene": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/urbangene",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/urbangene\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/urbangene\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/urbangene\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10244\", \"unit_name\": \"lasig\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/urbangene"
+          },
+          "test_migration_wp__labs__vdg": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/vdg",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/vdg\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/vdg\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/vdg\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"11271\", \"unit_name\": \"vdg\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/vdg"
+          },
+          "test_migration_wp__labs__vita": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/vita",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/vita\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/vita\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/vita\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"13529\", \"unit_name\": \"vita\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/vita"
+          },
+          "test_migration_wp__labs__vlsc": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/vlsc",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/vlsc\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/vlsc\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/vlsc\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"12814\", \"unit_name\": \"vlsc\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/vlsc"
+          },
+          "test_migration_wp__labs__wire": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/wire",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/wire\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/wire\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/wire\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12172\", \"unit_name\": \"wire\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/wire"
+          },
+          "test_migration_wp__labs__ytm2019": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ytm2019",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ytm2019\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ytm2019\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ytm2019\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"13046\", \"unit_name\": \"uphess\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ytm2019"
+          },
+          "test_migration_wp__labs__ytm2019_test_hugo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "labs/ytm2019_test_hugo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/labs/ytm2019_test_hugo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/labs/ytm2019_test_hugo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"labs/ytm2019_test_hugo\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"en\"], \"unit_id\": \"13046\", \"unit_name\": \"uphess\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/labs/ytm2019_test_hugo"
+          },
+          "test_migration_wp__lulu__gfo": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "lulu/gfo",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/lulu/gfo\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/lulu/gfo\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"lulu/gfo\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\"], \"unit_id\": \"12146\", \"unit_name\": \"sci-sti-lt\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/lulu/gfo"
+          },
+          "test_migration_wp__polylex": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "polylex",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/polylex\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/polylex\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"polylex\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10005\", \"unit_name\": \"aj\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/polylex"
+          },
+          "test_migration_wp__polylex2": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "polylex2",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/polylex2\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/polylex2\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"polylex2\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"10005\", \"unit_name\": \"aj\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/polylex2"
+          },
+          "test_migration_wp__test_wpforms": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "test-wpforms",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/test-wpforms\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/test-wpforms\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"test-wpforms\", \"categories\": [\"Payonline\", \"WPForms\"], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"13030\", \"unit_name\": \"idev-fsd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/test-wpforms"
+          },
+          "test_migration_wp__wpforms_test": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "migration-wp.epfl.ch",
+              "wp_path": "wpforms-test",
+              "wpveritas_site": "{\"url\": \"https://migration-wp.epfl.ch/wpforms-test\", \"parsed_url\": [\"https\", \"migration-wp.epfl.ch\", \"/wpforms-test\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"migration-wp.epfl.ch\", \"wp_path\": \"wpforms-test\", \"categories\": [\"Payonline\", \"WPForms\"], \"theme\": \"wp-theme-2018\", \"languages\": [\"en\", \"fr\"], \"unit_id\": \"13030\", \"unit_name\": \"idev-fsd\"}",
+              "wpveritas_url": "https://migration-wp.epfl.ch/wpforms-test"
+          },
+          "test_subdomains_lite2": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "int",
+              "wp_hostname": "subdomains-lite2.epfl.ch",
+              "wp_path": "",
+              "wpveritas_site": "{\"url\": \"https://subdomains-lite2.epfl.ch\", \"parsed_url\": [\"https\", \"subdomains-lite2.epfl.ch\", \"\", \"\", \"\", \"\"], \"wwp_env\": \"int\", \"wp_hostname\": \"subdomains-lite2.epfl.ch\", \"wp_path\": \"\", \"categories\": [], \"theme\": \"wp-theme-2018\", \"languages\": [\"fr\"], \"unit_id\": \"13030\", \"unit_name\": \"idev-fsd\"}",
+              "wpveritas_url": "https://subdomains-lite2.epfl.ch"
+          },
+          "test_www_nolossproject_eu": {
+              "ansible_connection": "ssh",
+              "ansible_python_interpreter": "/usr/bin/python3",
+              "ansible_ssh_host": "test-ssh-wwp.epfl.ch",
+              "ansible_ssh_port": 32222,
+              "ansible_ssh_user": "www-data",
+              "openshift_namespace": "wwp-test",
+              "wp_env": "subdomains-lite",
+              "wp_hostname": "www.nolossproject.eu",
+              "wp_path": "",
+              "wpveritas_site": "{\"url\": \"https://www.nolossproject.eu\", \"parsed_url\": [\"https\", \"www.nolossproject.eu\", \"\", \"\", \"\", \"\"], \"wwp_env\": \"subdomains-lite\", \"wp_hostname\": \"www.nolossproject.eu\", \"wp_path\": \"\", \"categories\": [], \"theme\": \"wp-theme-light\", \"languages\": [\"fr\", \"en\"], \"unit_id\": \"13030\", \"unit_name\": \"idev-fsd\"}",
+              "wpveritas_url": "https://www.nolossproject.eu"
           }
       }
   },
-  "all-wordpresses": {
+  "all_wordpresses": {
       "children": [
-          "test-wordpresses"
+          "test_wordpresses"
       ]
   },
-  "test-dev": {
+  "test_int": {
       "hosts": [
-          "wp1_os_exopge__dcsl",
-          "wp5_os_exopge__site10",
-          "wp5_os_exopge__site11",
-          "wp5_os_exopge__test",
-          "wp5_os_exopge__test_varnish",
-          "wp5_os_exopge__test_varnish2",
-          "migration__dcsl"
+          "test_migration_wp__emploi",
+          "test_migration_wp__chaire_gaz_naturel",
+          "test_migration_wp__labs__ablasserlab",
+          "test_migration_wp__labs__acces",
+          "test_migration_wp__labs__alice",
+          "test_migration_wp__labs__acht",
+          "test_migration_wp__labs__acm",
+          "test_migration_wp__labs__alinek",
+          "test_migration_wp__labs__anchp",
+          "test_migration_wp__labs__amcv",
+          "test_migration_wp__labs__anmath",
+          "test_migration_wp__labs__anmc",
+          "test_migration_wp__labs__apc",
+          "test_migration_wp__labs__aprl",
+          "test_migration_wp__labs__archizoom",
+          "test_migration_wp__labs__aphys",
+          "test_migration_wp__labs__aqua",
+          "test_migration_wp__labs__aspg",
+          "test_migration_wp__labs__auwerx_lab",
+          "test_migration_wp__labs__barth_lab",
+          "test_migration_wp__labs__biorob",
+          "test_migration_wp__labs__bios",
+          "test_migration_wp__labs__bpe",
+          "test_migration_wp__labs__blokesch_lab",
+          "test_migration_wp__labs__building2050",
+          "test_migration_wp__labs__brisken_lab",
+          "test_migration_wp__labs__cag",
+          "test_migration_wp__labs__c3mp",
+          "test_migration_wp__labs__cama",
+          "test_migration_wp__labs__cclab",
+          "test_migration_wp__labs__cdh_test",
+          "test_migration_wp__labs__cdt",
+          "test_migration_wp__labs__ceat",
+          "test_migration_wp__labs__cemi",
+          "test_migration_wp__labs__cen",
+          "test_migration_wp__labs__chaire_gaz_naturel",
+          "test_migration_wp__labs__clse",
+          "test_migration_wp__labs__cgd",
+          "test_migration_wp__labs__cole_lab",
+          "test_migration_wp__labs__cnpa",
+          "test_migration_wp__labs__constam_lab",
+          "test_migration_wp__labs__concours_alkindi",
+          "test_migration_wp__labs__courtine_lab",
+          "test_migration_wp__labs__cosmo",
+          "test_migration_wp__labs__cryos",
+          "test_migration_wp__labs__csqi",
+          "test_migration_wp__labs__cvlab",
+          "test_migration_wp__labs__data",
+          "test_migration_wp__labs__datathink",
+          "test_migration_wp__labs__dcg",
+          "test_migration_wp__labs__dcml",
+          "test_migration_wp__labs__dcsl",
+          "test_migration_wp__labs__dedis",
+          "test_migration_wp__labs__bucher_lab",
+          "test_migration_wp__labs__dias",
+          "test_migration_wp__labs__dhlab",
+          "test_migration_wp__labs__digitalfutures",
+          "test_migration_wp__labs__disal",
+          "test_migration_wp__labs__disopt",
+          "test_migration_wp__labs__duboule_lab",
+          "test_migration_wp__labs__east",
+          "test_migration_wp__labs__dynnet",
+          "test_migration_wp__labs__ecol",
+          "test_migration_wp__labs__echo",
+          "test_migration_wp__labs__ecotox",
+          "test_migration_wp__labs__ecps",
+          "test_migration_wp__labs__edlab",
+          "test_migration_wp__labs__eelab",
+          "test_migration_wp__labs__desl_pwrs",
+          "test_migration_wp__labs__elab",
+          "test_migration_wp__labs__eesd",
+          "test_migration_wp__labs__eml",
+          "test_migration_wp__labs__emsi",
+          "test_migration_wp__labs__emc",
+          "test_migration_wp__labs__emplus",
+          "test_migration_wp__labs__enac_am",
+          "test_migration_wp__labs__entc",
+          "test_migration_wp__labs__enacit2",
+          "test_migration_wp__labs__esl",
+          "test_migration_wp__labs__epsl",
+          "test_migration_wp__labs__expertise",
+          "test_migration_wp__labs__fellay_lab",
+          "test_migration_wp__labs__ffo",
+          "test_migration_wp__labs__fimap",
+          "test_migration_wp__labs__form",
+          "test_migration_wp__labs__flexlab",
+          "test_migration_wp__labs__fsl",
+          "test_migration_wp__labs__galatea",
+          "test_migration_wp__labs__gel",
+          "test_migration_wp__labs__gem",
+          "test_migration_wp__labs__gemini_e3",
+          "test_migration_wp__labs__genomic_resources",
+          "test_migration_wp__labs__gfo",
+          "test_migration_wp__labs__gis",
+          "test_migration_wp__labs__gonczy_lab",
+          "test_migration_wp__labs__gr_cel",
+          "test_migration_wp__labs__graefflab",
+          "test_migration_wp__labs__gr_tes",
+          "test_migration_wp__labs__grpi",
+          "test_migration_wp__labs__gramm",
+          "test_migration_wp__labs__hanahan_lab",
+          "test_migration_wp__labs__habitat",
+          "test_migration_wp__labs__herus",
+          "test_migration_wp__labs__hessbellwald_lab",
+          "test_migration_wp__labs__het",
+          "test_migration_wp__labs__hl",
+          "test_migration_wp__labs__hobel",
+          "test_migration_wp__labs__huelsken_lab",
+          "test_migration_wp__labs__iahr2020",
+          "test_migration_wp__labs__hummel_lab",
+          "test_migration_wp__labs__ibois",
+          "test_migration_wp__labs__iclab",
+          "test_migration_wp__labs__ict4sm",
+          "test_migration_wp__labs__icnf2019",
+          "test_migration_wp__labs__idiap",
+          "test_migration_wp__labs__ideas",
+          "test_migration_wp__labs__iig",
+          "test_migration_wp__labs__imac",
+          "test_migration_wp__labs__instantlab",
+          "test_migration_wp__labs__innoseed_enac",
+          "test_migration_wp__labs__iphys_it",
+          "test_migration_wp__labs__ipese",
+          "test_migration_wp__labs__ivrl",
+          "test_migration_wp__labs__isic",
+          "test_migration_wp__labs__k_lab",
+          "test_migration_wp__labs__la",
+          "test_migration_wp__labs__laba",
+          "test_migration_wp__labs__lab_u",
+          "test_migration_wp__labs__lacal",
+          "test_migration_wp__labs__labos",
+          "test_migration_wp__labs__lai",
+          "test_migration_wp__labs__lammm",
+          "test_migration_wp__labs__lamp",
+          "test_migration_wp__labs__lams_next",
+          "test_migration_wp__labs__lanes",
+          "test_migration_wp__labs__lap",
+          "test_migration_wp__labs__lapd",
+          "test_migration_wp__labs__lapi",
+          "test_migration_wp__labs__lapis",
+          "test_migration_wp__labs__lasa",
+          "test_migration_wp__labs__lashuel_lab",
+          "test_migration_wp__labs__lasig",
+          "test_migration_wp__labs__laspe",
+          "test_migration_wp__labs__last",
+          "test_migration_wp__labs__lastro",
+          "test_migration_wp__labs__lasur",
+          "test_migration_wp__labs__lbm",
+          "test_migration_wp__labs__lbe",
+          "test_migration_wp__labs__lbni",
+          "test_migration_wp__labs__lbo",
+          "test_migration_wp__labs__lbp",
+          "test_migration_wp__labs__lcav",
+          "test_migration_wp__labs__lbs",
+          "test_migration_wp__labs__lce",
+          "test_migration_wp__labs__lcc",
+          "test_migration_wp__labs__lcn",
+          "test_migration_wp__labs__lch",
+          "test_migration_wp__labs__lcvmm",
+          "test_migration_wp__labs__lcpm",
+          "test_migration_wp__labs__ldm",
+          "test_migration_wp__labs__leb",
+          "test_migration_wp__labs__leago",
+          "test_migration_wp__labs__lemaitrelab",
+          "test_migration_wp__labs__lemr",
+          "test_migration_wp__labs__len",
+          "test_migration_wp__labs__leure",
+          "test_migration_wp__labs__leso",
+          "test_migration_wp__labs__lhtc",
+          "test_migration_wp__labs__lifmet",
+          "test_migration_wp__labs__lfmi",
+          "test_migration_wp__labs__lions",
+          "test_migration_wp__labs__lgb",
+          "test_migration_wp__labs__lingner_lab",
+          "test_migration_wp__labs__linx",
+          "test_migration_wp__labs__lipid",
+          "test_migration_wp__labs__lmaf",
+          "test_migration_wp__labs__lmam",
+          "test_migration_wp__labs__lis",
+          "test_migration_wp__labs__lmis1",
+          "test_migration_wp__labs__lmgn",
+          "test_migration_wp__labs__lmis2",
+          "test_migration_wp__labs__lmc",
+          "test_migration_wp__labs__lmis4",
+          "test_migration_wp__labs__lmh",
+          "test_migration_wp__labs__lmm",
+          "test_migration_wp__labs__lms",
+          "test_migration_wp__labs__lmsc",
+          "test_migration_wp__labs__lmom",
+          "test_migration_wp__labs__lmtm",
+          "test_migration_wp__labs__lmts",
+          "test_migration_wp__labs__lnb",
+          "test_migration_wp__labs__lnce",
+          "test_migration_wp__labs__lnco",
+          "test_migration_wp__labs__lnd",
+          "test_migration_wp__labs__lns",
+          "test_migration_wp__labs__lne",
+          "test_migration_wp__labs__lpac",
+          "test_migration_wp__labs__lo",
+          "test_migration_wp__labs__lp",
+          "test_migration_wp__labs__lpap",
+          "test_migration_wp__labs__lpbs",
+          "test_migration_wp__labs__lphe",
+          "test_migration_wp__labs__lpi",
+          "test_migration_wp__labs__lpmat",
+          "test_migration_wp__labs__lpmc",
+          "test_migration_wp__labs__lpdi",
+          "test_migration_wp__labs__lpmn",
+          "test_migration_wp__labs__lpn",
+          "test_migration_wp__labs__lptp",
+          "test_migration_wp__labs__lpmv",
+          "test_migration_wp__labs__lppc",
+          "test_migration_wp__labs__lqm",
+          "test_migration_wp__labs__lqno",
+          "test_migration_wp__labs__lppt",
+          "test_migration_wp__labs__lrs",
+          "test_migration_wp__labs__lqg",
+          "test_migration_wp__labs__lse",
+          "test_migration_wp__labs__lrese",
+          "test_migration_wp__labs__lrm",
+          "test_migration_wp__labs__lsi",
+          "test_migration_wp__labs__lsbi",
+          "test_migration_wp__labs__lsir",
+          "test_migration_wp__labs__lsis",
+          "test_migration_wp__labs__lsen",
+          "test_migration_wp__labs__lsms",
+          "test_migration_wp__labs__lsme",
+          "test_migration_wp__labs__lsp",
+          "test_migration_wp__labs__lte",
+          "test_migration_wp__labs__lsym",
+          "test_migration_wp__labs__lth3",
+          "test_migration_wp__labs__ltqe",
+          "test_migration_wp__labs__lts4",
+          "test_migration_wp__labs__lts5www",
+          "test_migration_wp__labs__lumes",
+          "test_migration_wp__labs__lwe",
+          "test_migration_wp__labs__luts",
+          "test_migration_wp__labs__mag",
+          "test_migration_wp__labs__manslab",
+          "test_migration_wp__labs__markram_lab",
+          "test_migration_wp__labs__master_architecture",
+          "test_migration_wp__labs__mckinney_lab",
+          "test_migration_wp__labs__mccabelab",
+          "test_migration_wp__labs__mechanical_spectroscopy",
+          "test_migration_wp__labs__mcs",
+          "test_migration_wp__labs__mhmc",
+          "test_migration_wp__labs__meylan_lab",
+          "test_migration_wp__labs__microbs",
+          "test_migration_wp__labs__mir",
+          "test_migration_wp__labs__mlo",
+          "test_migration_wp__labs__mmspg",
+          "test_migration_wp__labs__mns",
+          "test_migration_wp__labs__naef_lab",
+          "test_migration_wp__labs__nal",
+          "test_migration_wp__labs__nanolab",
+          "test_migration_wp__labs__naveiras_lab",
+          "test_migration_wp__labs__nems",
+          "test_migration_wp__labs__nm2",
+          "test_migration_wp__labs__nextgen",
+          "test_migration_wp__labs__nolossproject",
+          "test_migration_wp__labs__nsbl",
+          "test_migration_wp__labs__ntcm2018",
+          "test_migration_wp__labs__oateslab",
+          "test_migration_wp__labs__pcsl",
+          "test_migration_wp__labs__pbl",
+          "test_migration_wp__labs__pel",
+          "test_migration_wp__labs__pde",
+          "test_migration_wp__labs__persat_lab",
+          "test_migration_wp__labs__phosl",
+          "test_migration_wp__labs__pixe",
+          "test_migration_wp__labs__plte",
+          "test_migration_wp__labs__powerlab",
+          "test_migration_wp__labs__prob",
+          "test_migration_wp__labs__prst",
+          "test_migration_wp__labs__ptbtg",
+          "test_migration_wp__labs__q_lab",
+          "test_migration_wp__labs__pvlab",
+          "test_migration_wp__labs__ramdya_lab",
+          "test_migration_wp__labs__radtke_lab",
+          "test_migration_wp__labs__react",
+          "test_migration_wp__labs__rao",
+          "test_migration_wp__labs__resslab",
+          "test_migration_wp__labs__rfic",
+          "test_migration_wp__labs__rrl",
+          "test_migration_wp__labs__sber",
+          "test_migration_wp__labs__schoonjans_lab",
+          "test_migration_wp__labs__scaffolds2018",
+          "test_migration_wp__labs__servicedesk_sandbox",
+          "test_migration_wp__labs__sci_sb_rh",
+          "test_migration_wp__labs__simanis_lab",
+          "test_migration_wp__labs__skil",
+          "test_migration_wp__labs__smal",
+          "test_migration_wp__labs__smat",
+          "test_migration_wp__labs__spc",
+          "test_migration_wp__labs__sois",
+          "test_migration_wp__labs__spring",
+          "test_migration_wp__labs__sps",
+          "test_migration_wp__labs__stap",
+          "test_migration_wp__labs__stat",
+          "test_migration_wp__labs__sunmil",
+          "test_migration_wp__labs__sxl2",
+          "test_migration_wp__labs__tan",
+          "test_migration_wp__labs__tcl",
+          "test_migration_wp__labs__tang_lab",
+          "test_migration_wp__labs__tebel",
+          "test_migration_wp__labs__test_medias",
+          "test_migration_wp__labs__test_slug",
+          "test_migration_wp__labs__test_polylex",
+          "test_migration_wp__labs__tic",
+          "test_migration_wp__labs__theos",
+          "test_migration_wp__labs__topo",
+          "test_migration_wp__labs__tsam",
+          "test_migration_wp__labs__tox",
+          "test_migration_wp__labs__urbangene",
+          "test_migration_wp__labs__unfold",
+          "test_migration_wp__labs__vlsc",
+          "test_migration_wp__labs__vdg",
+          "test_migration_wp__labs__vita",
+          "test_migration_wp__labs__ytm2019",
+          "test_migration_wp__labs__wire",
+          "test_migration_wp__labs__ytm2019_test_hugo",
+          "test_migration_wp__polylex",
+          "test_migration_wp__lulu__gfo",
+          "test_migration_wp__polylex2",
+          "test_subdomains_lite2",
+          "test_migration_wp__labs__aaa",
+          "test_migration_wp__wpforms_test",
+          "test_migration_wp__test_wpforms"
       ]
   },
-  "test-gcharmier": {
+  "test_subdomains_lite": {
       "hosts": [
-          "env_gc_os_exopge__nm2",
-          "env_gc_os_exopge__bios",
-          "env_gc_os_exopge__c3mp",
-          "env_gc_os_exopge__cns",
-          "env_gc_os_exopge__dcgprogram",
-          "env_gc_os_exopge__decouvrir_le_numerique",
-          "env_gc_os_exopge__dynnet",
-          "env_gc_os_exopge__ekv",
-          "env_gc_os_exopge__entrepreneurship",
-          "env_gc_os_exopge__euclid",
-          "env_gc_os_exopge__gonczy_lab",
-          "env_gc_os_exopge__hsca",
-          "env_gc_os_exopge__innoseed_enac",
-          "env_gc_os_exopge__lcvmm",
-          "env_gc_os_exopge__ldia2019",
-          "env_gc_os_exopge__lmaf",
-          "env_gc_os_exopge__lpmn",
-          "env_gc_os_exopge__lprx",
-          "env_gc_os_exopge__mechanical_spectroscopy",
-          "env_gc_os_exopge__nal",
-          "env_gc_os_exopge__nextgen",
-          "env_gc_os_exopge__nnbe",
-          "env_gc_os_exopge__nrg2018",
-          "env_gc_os_exopge__ntti2017",
-          "env_gc_os_exopge__polylex",
-          "env_gc_os_exopge__pvlab",
-          "env_gc_os_exopge__qed",
-          "env_gc_os_exopge__qtca2018",
-          "env_gc_os_exopge__r4l",
-          "env_gc_os_exopge__rdsg",
-          "env_gc_os_exopge__repro",
-          "env_gc_os_exopge__sb",
-          "env_gc_os_exopge__sfbe",
-          "env_gc_os_exopge__systems",
-          "env_gc_os_exopge__theos",
-          "env_gc_os_exopge__cag",
-          "env_gc_os_exopge__gfo",
-          "env_gc_os_exopge__microbs",
-          "env_gc_os_exopge__naveiras_lab",
-          "env_gc_os_exopge__pde",
-          "env_gc_os_exopge__react",
-          "env_gc_os_exopge__icss12",
-          "env_gc_os_exopge__ggsd",
-          "env_gc_os_exopge__skyrmions",
-          "env_gc_os_exopge__gr_ost",
-          "env_gc_os_exopge__labos",
-          "env_gc_os_exopge__mlo",
-          "env_gc_os_exopge__yac",
-          "no_local_env__dcsl",
-          "migration_wp__cag"
+          "test_www_nolossproject_eu"
       ]
   },
-  "test-int": {
-      "hosts": [
-          "migration_wp__emploi",
-          "wp1_os_exopge__galatea",
-          "migration_wp__polylex",
-          "migration_wp__polylex2",
-          "migration_wp__lulu__gfo",
-          "migration_wp__emploi1",
-          "migration_wp__chaire_gaz_naturel",
-          "migration_wp__labs__sps",
-          "migration_wp__labs__lts4",
-          "migration_wp__labs__dcsl",
-          "migration_wp__labs__amcv",
-          "migration_wp__labs__spc",
-          "migration_wp__labs__alice",
-          "migration_wp__labs__lab_u",
-          "migration_wp__labs__ldm",
-          "migration_wp__labs__leure",
-          "migration_wp__labs__lapis",
-          "migration_wp__labs__skil",
-          "migration_wp__labs__cclab",
-          "migration_wp__labs__gr_cel",
-          "migration_wp__labs__disal",
-          "migration_wp__labs__ibois",
-          "migration_wp__labs__gis",
-          "migration_wp__labs__vita",
-          "migration_wp__labs__master_architecture",
-          "migration_wp__labs__manslab",
-          "migration_wp__labs__eesd",
-          "migration_wp__labs__enacit2",
-          "migration_wp__labs__innoseed_enac",
-          "migration_wp__labs__acm",
-          "migration_wp__labs__ceat",
-          "migration_wp__labs__enac_am",
-          "migration_wp__labs__pixe",
-          "migration_wp__labs__plte",
-          "migration_wp__labs__habitat",
-          "migration_wp__labs__ecotox",
-          "migration_wp__labs__wire",
-          "migration_wp__labs__topo",
-          "migration_wp__labs__tsam",
-          "migration_wp__labs__sber",
-          "migration_wp__labs__luts",
-          "migration_wp__labs__ltqe",
-          "migration_wp__labs__lte",
-          "migration_wp__labs__lth3",
-          "migration_wp__labs__lipid",
-          "migration_wp__labs__lgb",
-          "migration_wp__labs__leso",
-          "migration_wp__labs__gemini_e3",
-          "migration_wp__labs__lemr",
-          "migration_wp__labs__lcc",
-          "migration_wp__labs__lch",
-          "migration_wp__labs__lce",
-          "migration_wp__labs__urbangene",
-          "migration_wp__labs__lasur",
-          "migration_wp__labs__lbe",
-          "migration_wp__labs__genomic_resources",
-          "migration_wp__labs__nextgen",
-          "migration_wp__labs__lasig",
-          "migration_wp__labs__laba",
-          "migration_wp__labs__imac",
-          "migration_wp__labs__ideas",
-          "migration_wp__labs__herus",
-          "migration_wp__labs__gel",
-          "migration_wp__labs__form",
-          "migration_wp__labs__lap",
-          "migration_wp__labs__eml",
-          "migration_wp__labs__datathink",
-          "migration_wp__labs__east",
-          "migration_wp__labs__ecol",
-          "migration_wp__labs__cryos",
-          "migration_wp__labs__cnpa",
-          "migration_wp__labs__chaire_gaz_naturel",
-          "migration_wp__labs__cdt",
-          "migration_wp__labs__echo",
-          "migration_wp__labs__acht",
-          "migration_wp__labs__expertise",
-          "migration_wp__labs__archizoom",
-          "migration_wp__labs__building2050",
-          "migration_wp__labs__la",
-          "migration_wp__labs__lbni",
-          "migration_wp__labs__markram_lab",
-          "migration_wp__labs__oateslab",
-          "migration_wp__labs__isic",
-          "migration_wp__labs__barth_lab",
-          "migration_wp__labs__ablasserlab",
-          "migration_wp__labs__lbm",
-          "migration_wp__labs__rrl",
-          "migration_wp__labs__lapi",
-          "migration_wp__labs__lcav",
-          "migration_wp__labs__cen",
-          "migration_wp__labs__iphys_it",
-          "migration_wp__labs__lp",
-          "migration_wp__labs__last",
-          "migration_wp__labs__tebel",
-          "migration_wp__labs__gfo",
-          "migration_wp__labs__cosmo",
-          "migration_wp__labs__mir",
-          "migration_wp__labs__naef_lab",
-          "migration_wp__labs__lcn",
-          "migration_wp__labs__bpe",
-          "migration_wp__labs__lppt",
-          "migration_wp__labs__emsi",
-          "migration_wp__labs__dcml",
-          "migration_wp__labs__mmspg",
-          "migration_wp__labs__lmis4",
-          "migration_wp__labs__pvlab",
-          "migration_wp__labs__aphys",
-          "migration_wp__labs__aprl",
-          "migration_wp__labs__lms",
-          "migration_wp__labs__lsms",
-          "migration_wp__labs__mcs",
-          "migration_wp__labs__resslab",
-          "migration_wp__labs__sxl2",
-          "migration_wp__labs__tox",
-          "migration_wp__labs__scaffolds2018",
-          "migration_wp__labs__cemi",
-          "migration_wp__labs__mckinney_lab",
-          "migration_wp__labs__duboule_lab",
-          "migration_wp__labs__gramm",
-          "migration_wp__labs__vdg",
-          "migration_wp__labs__lmis1",
-          "migration_wp__labs__lacal",
-          "migration_wp__labs__brisken_lab",
-          "migration_wp__labs__len",
-          "migration_wp__labs__ptbtg",
-          "migration_wp__labs__digitalfutures",
-          "migration_wp__labs__graefflab",
-          "migration_wp__labs__fellay_lab",
-          "migration_wp__labs__constam_lab",
-          "migration_wp__labs__hanahan_lab",
-          "migration_wp__labs__radtke_lab",
-          "migration_wp__labs__simanis_lab",
-          "migration_wp__labs__hummel_lab",
-          "migration_wp__labs__lrm",
-          "migration_wp__labs__lbo",
-          "migration_wp__labs__rao",
-          "migration_wp__labs__lpmc",
-          "migration_wp__labs__lemaitrelab",
-          "migration_wp__labs__vlsc",
-          "migration_wp__labs__courtine_lab",
-          "migration_wp__labs__lpap",
-          "migration_wp__labs__hobel",
-          "migration_wp__labs__entc",
-          "migration_wp__labs__nems",
-          "migration_wp__labs__lingner_lab",
-          "migration_wp__labs__lmsc",
-          "migration_wp__labs__lmis2",
-          "migration_wp__labs__meylan_lab",
-          "migration_wp__labs__lpmv",
-          "migration_wp__labs__lmgn",
-          "migration_wp__labs__chili",
-          "migration_wp__labs__lqm",
-          "migration_wp__labs__nm2",
-          "migration_wp__labs__ramdya_lab",
-          "migration_wp__labs__ffo",
-          "migration_wp__labs__react",
-          "migration_wp__labs__lppc",
-          "migration_wp__labs__lnco",
-          "migration_wp__labs__mag",
-          "migration_wp__labs__gonczy_lab",
-          "migration_wp__labs__concours_alkindi",
-          "migration_wp__labs__leago",
-          "migration_wp__labs__lpi",
-          "migration_wp__labs__nolossproject",
-          "migration_wp__labs__lsym",
-          "migration_wp__labs__lashuel_lab",
-          "migration_wp__labs__aspg",
-          "migration_wp__labs__grpi",
-          "migration_wp__labs__lnd",
-          "migration_wp__labs__lsp",
-          "migration_wp__labs__clse",
-          "migration_wp__labs__stap",
-          "migration_wp__labs__stat",
-          "migration_wp__labs__blokesch_lab",
-          "migration_wp__labs__lns",
-          "migration_wp__labs__smal",
-          "migration_wp__labs__dias",
-          "migration_wp__labs__lsir",
-          "migration_wp__labs__servicedesk_sandbox",
-          "migration_wp__labs__k_lab",
-          "migration_wp__labs__lnb",
-          "migration_wp__labs__lnce",
-          "migration_wp__labs__aqua",
-          "migration_wp__labs__anmc",
-          "migration_wp__labs__biorob",
-          "migration_wp__labs__bios",
-          "migration_wp__labs__cole_lab",
-          "migration_wp__labs__ipese",
-          "migration_wp__labs__anchp",
-          "migration_wp__labs__cvlab",
-          "migration_wp__labs__flexlab",
-          "migration_wp__labs__iahr2020",
-          "migration_wp__labs__microbs",
-          "migration_wp__labs__unfold",
-          "migration_wp__labs__lams_next",
-          "migration_wp__labs__prst",
-          "migration_wp__labs__prob",
-          "migration_wp__labs__iig",
-          "migration_wp__labs__tang_lab",
-          "migration_wp__labs__sois",
-          "migration_wp__labs__cdh_test",
-          "migration_wp__labs__lamp",
-          "migration_wp__labs__galatea",
-          "migration_wp__labs__lsme",
-          "migration_wp__labs__csqi",
-          "migration_wp__labs__pde",
-          "migration_wp__labs__mccabelab",
-          "migration_wp__labs__desl_pwrs",
-          "migration_wp__labs__ytm2019",
-          "migration_wp__labs__spring",
-          "migration_wp__labs__ytm2019_test_hugo",
-          "migration_wp__labs__esl",
-          "migration_wp__labs__tan",
-          "migration_wp__labs__iclab",
-          "migration_wp__labs__rfic",
-          "migration_wp__labs__q_lab",
-          "migration_wp__labs__phosl",
-          "migration_wp__labs__edlab",
-          "migration_wp__labs__test_medias",
-          "migration_wp__labs__emplus",
-          "migration_wp__labs__naveiras_lab",
-          "migration_wp__labs__epsl",
-          "migration_wp__labs__nanolab",
-          "migration_wp__labs__fsl",
-          "migration_wp__labs__dynnet",
-          "migration_wp__labs__mechanical_spectroscopy",
-          "migration_wp__labs__sci_sb_rh",
-          "migration_wp__labs__lptp",
-          "migration_wp__labs__hessbellwald_lab",
-          "migration_wp__labs__gem",
-          "migration_wp__labs__mlo",
-          "migration_wp__labs__ivrl",
-          "migration_wp__labs__mhmc",
-          "migration_wp__labs__lai",
-          "migration_wp__labs__cama",
-          "migration_wp__labs__lammm",
-          "migration_wp__labs__smat",
-          "migration_wp__labs__lanes",
-          "migration_wp__labs__lapd",
-          "migration_wp__labs__nsbl",
-          "migration_wp__labs__persat_lab",
-          "migration_wp__labs__schoonjans_lab",
-          "migration_wp__labs__lbp",
-          "migration_wp__labs__test_slug",
-          "migration_wp__labs__elab",
-          "migration_wp__labs__lwe",
-          "migration_wp__labs__lhtc",
-          "migration_wp__labs__lse",
-          "migration_wp__labs__lrs",
-          "migration_wp__labs__test_polylex",
-          "migration_wp__labs__lasa",
-          "migration_wp__labs__dhlab",
-          "migration_wp__labs__lrese",
-          "migration_wp__labs__lqg",
-          "migration_wp__labs__lpmn",
-          "migration_wp__labs__lpac",
-          "migration_wp__labs__lo",
-          "migration_wp__labs__auwerx_lab",
-          "migration_wp__labs__ecps",
-          "migration_wp__labs__lphe",
-          "migration_wp__labs__lne",
-          "migration_wp__labs__idiap",
-          "migration_wp__labs__leb",
-          "migration_wp__labs__lts5www",
-          "migration_wp__labs__lmts",
-          "migration_wp__labs__tcl",
-          "migration_wp__labs__lfmi",
-          "migration_wp__labs__lmtm",
-          "migration_wp__labs__lcpm",
-          "migration_wp__labs__lis",
-          "migration_wp__labs__lmam",
-          "migration_wp__labs__lmm",
-          "migration_wp__labs__instantlab",
-          "migration_wp__labs__lcvmm",
-          "migration_wp__labs__gr_tes",
-          "migration_wp__labs__tic",
-          "migration_wp__labs__icnf2019",
-          "migration_wp__labs__lmom",
-          "migration_wp__labs__fimap",
-          "migration_wp__labs__lions",
-          "migration_wp__labs__powerlab",
-          "migration_wp__labs__laspe",
-          "migration_wp__labs__lpbs",
-          "migration_wp__labs__pel",
-          "migration_wp__labs__lqno",
-          "migration_wp__labs__pbl",
-          "migration_wp__labs__theos",
-          "migration_wp__labs__acces",
-          "migration_wp__labs__ict4sm",
-          "migration_wp__labs__disopt",
-          "migration_wp__labs__hl",
-          "migration_wp__labs__labos",
-          "migration_wp__labs__lifmet",
-          "migration_wp__labs__lastro",
-          "migration_wp__labs__lmaf",
-          "migration_wp__labs__ntcm2018",
-          "migration_wp__labs__dcg",
-          "migration_wp__labs__lsbi",
-          "migration_wp__labs__mns",
-          "migration_wp__labs__anmath",
-          "migration_wp__labs__cgd",
-          "migration_wp__labs__cag",
-          "migration_wp__labs__apc",
-          "migration_wp__labs__lmh",
-          "migration_wp__labs__bucher_lab",
-          "migration_wp__labs__lbs",
-          "migration_wp__labs__lpn",
-          "migration_wp__labs__lmc",
-          "migration_wp__labs__c3mp",
-          "migration_wp__labs__emc",
-          "migration_wp__labs__het",
-          "migration_wp__labs__lsen",
-          "migration_wp__labs__sunmil",
-          "migration_wp__labs__lsis",
-          "migration_wp__labs__lumes",
-          "migration_wp__labs__dedis",
-          "migration_wp__labs__eelab",
-          "migration_wp__labs__huelsken_lab",
-          "migration_wp__labs__pcsl",
-          "migration_wp__labs__linx",
-          "migration_wp__labs__nal",
-          "migration_wp__labs__lpmat",
-          "migration_wp__labs__data",
-          "migration_wp__labs__lpdi",
-          "migration_wp__labs__lsi",
-          "migration_wp__labs__alinek",
-          "test_wp__testlulu",
-          "test_wp__campus__services",
-          "test_wp",
-          "test_wp__labs__pvlab",
-          "test_wp__labs__cvlab",
-          "test_wp__labs__emc",
-          "test_wp__labs__la",
-          "test_wp__labs__last",
-          "test_wp__labs__dcsl"
-      ]
-  },
-  "test-lchaboudez": {
-      "hosts": [
-          "env_lc_os_exopge__cdhshs",
-          "env_lc_os_exopge__gutenberg"
-      ]
-  },
-  "test-wordpresses": {
+  "test_wordpresses": {
       "children": [
-          "test-dev",
-          "test-int",
-          "test-gcharmier",
-          "test-lchaboudez",
-          "test-www"
-      ]
-  },
-  "test-www": {
-      "hosts": [
-          "charte_wp__www_epfl_ch"
+          "test_int",
+          "test_subdomains_lite"
       ]
   }
 }

--- a/cli/lib/db-helper.js
+++ b/cli/lib/db-helper.js
@@ -110,8 +110,6 @@ module.exports.insertOneSite = async function (
   client.close();
 };
 
-
-
 /**
  * Get category
  */

--- a/cli/lib/db-helper.js
+++ b/cli/lib/db-helper.js
@@ -110,22 +110,27 @@ module.exports.insertOneSite = async function (
   client.close();
 };
 
+
+
 /**
  * Get category
  */
-module.exports.getCategory = async function (
+module.exports.getCategories = async function (
   connectionString,
   target,
-  categoryName
+  categoriesName
 ) {
-  const client = await createClient(connectionString);
-  const db = getDB(target, client);
-  let category = await db
-    .collection("categories")
-    .find({ name: categoryName })
-    .toArray();
-  client.close();
-  return category;
+  let categories = []
+  for (let categoryName of categoriesName) {
+    const client = await createClient(connectionString);
+    const db = getDB(target, client);
+    let category = await db
+      .collection("categories")
+      .find({ name: categoryName }).toArray();
+    categories.push(category[0])
+    client.close();
+  }
+  return categories;
 };
 
 /**

--- a/cli/lib/helpers.js
+++ b/cli/lib/helpers.js
@@ -51,38 +51,34 @@ module.exports.loadData = async (destination, data) => {
       ) {
         stop = true;
       }
-      let url, title, categories, categoryName, theme, languages;
+
+      let site, url, title, categories, categoryName, theme, languages;
       if (!stop) {
         url = `https://${currentSite.wp_hostname}/${currentSite.wp_path}`;
         title = currentSite.wp_path;
-        categoryName =
-          currentSite["wp_details"]["options"]["epfl:site_category"];
-        if (categoryName == null) {
-          categoryName = "GeneralPublic";
-        }
+
+        site = JSON.parse(currentSite.wpveritas_site)
 
         // Get category object by category name
         let connectionString = dbHelpers.getConnectionString(destination);
 
         // Return a empty list if category is GeneralPublic
-        categories = await dbHelpers.getCategory(
+        categories = await dbHelpers.getCategories(
           connectionString,
           destination,
-          categoryName
+          site.categories
         );
 
-        theme = currentSite["wp_details"]["options"]["stylesheet"];
-        languages = currentSite["wp_details"]["polylang"]["langs"];
-
+        theme = site.theme
+        languages = site.languages
         if (!languages) {
           stop = true;
         }
       }
+
       if (!stop) {
-        let unitId =
-          currentSite["wp_details"]["options"]["plugin:epfl_accred:unit_id"];
-        let unitName =
-          currentSite["wp_details"]["options"]["plugin:epfl_accred:unit"];
+        let unitId = site.unit_id
+        let unitName = site.unit_name
 
         let siteDocument = {
           url: url,
@@ -102,15 +98,19 @@ module.exports.loadData = async (destination, data) => {
           slug: "",
           professors: [],
           tags: [],
+          isDeleted: false,
         };
 
-        let connectionString = dbHelpers.getConnectionString(destination);
+        console.log(siteDocument)
 
+        let connectionString = dbHelpers.getConnectionString(destination);
+        console.log(connectionString)
         await dbHelpers.insertOneSite(
           connectionString,
           destination,
           siteDocument
         );
+
       }
     });
   } catch (error) {

--- a/cli/lib/helpers.js
+++ b/cli/lib/helpers.js
@@ -101,10 +101,8 @@ module.exports.loadData = async (destination, data) => {
           isDeleted: false,
         };
 
-        console.log(siteDocument)
-
         let connectionString = dbHelpers.getConnectionString(destination);
-        console.log(connectionString)
+        
         await dbHelpers.insertOneSite(
           connectionString,
           destination,


### PR DESCRIPTION
Cette PR a pour but de mettre à jour le CLI qui permet entre autre de charger les data de tests.
Pour charger ces datas, on se base sur un fichier json donné par l'inventaire ansible.
Cet inventaire json avait changé ce qui par conséquence demandait des changements dans le CLI.

PR lié dans wp-ops: https://github.com/epfl-si/wp-ops/pull/353

Issue:
#115 