### PR TITLE
[feature] display icon in message preview

### DIFF
--- a/app/imports/api/methods/sites.js
+++ b/app/imports/api/methods/sites.js
@@ -373,14 +373,15 @@ const generateSite = new VeritasValidatedMethod({
           this.userId
         );
 
+        // TODO: it would be nice to add the duration in the message.
         let statusMsgNormalization = `The normalization for the site ${site.url} on wp-veritas`;
         if (status == "successful") {
-          statusMsgNormalization += ` was successful 🤘 #wpSiteNormalized`;
+          statusMsgNormalization = `🤘 ${statusMsgNormalization} was successful #wpSiteNormalized`;
           if (site.openshiftEnv === "subdomains-lite") {
             statusMsgNormalization += "\n⚠️ Don't forget to change the varnish configuration!";
           }
         } else {
-          statusMsgNormalization += ` failed ❌`;
+          statusMsgNormalization = `❌ ${statusMsgNormalization} failed`;
         }
         Telegram.sendMessage(statusMsgNormalization);
       }


### PR DESCRIPTION
This commit add the success/fail icon in front of the message in order to be able to see the status in the telegram notification message (w/ having to open it).