### PR TITLE
[fix] Shell options with meteor install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  METEOR_VERSION: 3.0-rc.4
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
 
       - name: Install meteor
         run: |
-          curl https://install.meteor.com | /bin/sh
+          curl https://install.meteor.com/?release=$METEOR_VERSION | sh
 
       - name: Test
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal
 ENV METEOR_VERSION=3.0-rc.4
 
 RUN apt -qy update && apt -qy install curl build-essential python3 git
-RUN curl https://install.meteor.com/?release=$METEOR_VERSION | bash -e -x
+RUN curl https://install.meteor.com/?release=$METEOR_VERSION | sh
 
 COPY ./app /usr/src/app/
 WORKDIR /usr/src/app/

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -21,7 +21,7 @@ RUN apt-get -yqq update \
         make \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://install.meteor.com/?release=$METEOR_VERSION | bash -e -x
+RUN curl https://install.meteor.com/?release=$METEOR_VERSION | sh
 ENV PATH=$PATH:/root/.meteor
 
 WORKDIR /app


### PR DESCRIPTION
Since grep returns an exit status of 1 when it doesn't find any match, it can cause -e to terminate the script even when there wasn't a real "error".